### PR TITLE
Configure .NET API base URL and remove Express proxy

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,13 +8,6 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:3001',
-        changeOrigin: true,
-        secure: false,
-      },
-    },
   },
   plugins: [
     react(),


### PR DESCRIPTION
## Purpose
The user has written a .NET API to connect to the database hosted at `https://localhost:7215` and wants to configure this as the base URL while removing references to the Express server.

## Code changes
- **Updated API base URL**: Changed default API base from `/api` to `https://localhost:7215` in `src/lib/api.ts`
- **Enhanced URL handling**: Added logic to strip trailing slashes from base URLs to ensure consistent formatting
- **Improved mock data fallback**: Modified mock data switching logic to only activate when using relative URLs (like `/api`) rather than absolute URLs
- **Removed Express proxy**: Deleted Vite proxy configuration for `/api` routes that previously forwarded to `http://localhost:3001`
- **Better error handling**: Updated error handling to avoid switching to mock mode when using external API endpoints

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5ef3b8d4f9e74f9fbce6ebb73f356960/pulse-works)

👀 [Preview Link](https://5ef3b8d4f9e74f9fbce6ebb73f356960-pulse-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5ef3b8d4f9e74f9fbce6ebb73f356960</projectId>-->
<!--<branchName>pulse-works</branchName>-->