### PR TITLE
Add Created column and update Last updated column in AssetType grid

### DIFF
--- a/src/components/admin/AssetTypeManagement.tsx
+++ b/src/components/admin/AssetTypeManagement.tsx
@@ -191,7 +191,8 @@ export default function AssetTypeManagement() {
                   <TableHead>Menu</TableHead>
                   <TableHead>Order</TableHead>
                   <TableHead>Survey Element</TableHead>
-                  <TableHead>Updated</TableHead>
+                  <TableHead>Created</TableHead>
+                  <TableHead>Last updated</TableHead>
                   <TableHead className="text-right">Actions</TableHead>
                 </TableRow>
               </TableHeader>
@@ -208,7 +209,8 @@ export default function AssetTypeManagement() {
                     <TableCell>{item.menuName || <span className="text-muted-foreground">—</span>}</TableCell>
                     <TableCell>{item.menuOrder ?? <span className="text-muted-foreground">—</span>}</TableCell>
                     <TableCell>{item.isSurveyElement ? <Badge className="bg-success text-success-foreground">Yes</Badge> : <Badge variant="outline">No</Badge>}</TableCell>
-                    <TableCell>{new Date(item.updatedAt).toLocaleDateString()}</TableCell>
+                    <TableCell>{item.createdAt ? new Date(item.createdAt).toLocaleString() : "—"}</TableCell>
+                    <TableCell>{item.updatedAt ? new Date(item.updatedAt).toLocaleString() : "-"}</TableCell>
                     <TableCell className="text-right space-x-2">
                       <Button variant="outline" size="sm" onClick={() => onEdit(item)} className="gap-1"><Pencil className="h-3 w-3" />Edit</Button>
                       <Button variant="outline" size="sm" onClick={() => onDelete(item.id)} className="gap-1 text-destructive hover:text-destructive"><Trash2 className="h-3 w-3" />Delete</Button>


### PR DESCRIPTION
## Purpose

The user requested improvements to the AssetType grid to better display timestamp information. They wanted to add a "Created" column and rename the existing "Updated" column to "Last updated", with proper handling for cases where the updated date is not available.

## Code changes

- Added a new "Created" column header to the AssetType grid table
- Renamed "Updated" column header to "Last updated" 
- Added a new table cell displaying the `createdAt` timestamp with fallback to "—" when not available
- Updated the existing updated timestamp cell to show "Last updated" with fallback to "-" when `updatedAt` is not available
- Changed date formatting from `toLocaleDateString()` to `toLocaleString()` to include time informationTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 18`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5ef3b8d4f9e74f9fbce6ebb73f356960/quantum-sanctuary)

👀 [Preview Link](https://5ef3b8d4f9e74f9fbce6ebb73f356960-quantum-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5ef3b8d4f9e74f9fbce6ebb73f356960</projectId>-->
<!--<branchName>quantum-sanctuary</branchName>-->