### PR TITLE
Integrate device and survey APIs for assignment popup

### DIFF
--- a/src/components/admin/DeviceAssignmentPanel.tsx
+++ b/src/components/admin/DeviceAssignmentPanel.tsx
@@ -10,16 +10,17 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { DeviceAssignment, Survey } from "@/types/admin";
-import { Device } from "../../types/valve";
-import { useDevices, useDeviceAssignments, useCreateDeviceAssignment, useUpdateDeviceAssignment } from "@/hooks/useApiQueries";
+import type { Device } from "@/lib/api";
+import { useDevices, useDeviceAssignments, useCreateDeviceAssignment, useUpdateDeviceAssignment, useSurveyMasters } from "@/hooks/useApiQueries";
 import { apiClient } from "@/lib/api";
 
 export default function DeviceAssignmentPanel() {
   const { data: assignmentsResp } = useDeviceAssignments({ limit: 1000 });
   const { data: devicesResp } = useDevices({ limit: 1000 });
+  const { data: surveyMastersResp } = useSurveyMasters({ limit: 1000, status: "ACTIVE" });
   const assignments: DeviceAssignment[] = assignmentsResp?.data ?? [];
   const devices: Device[] = (devicesResp?.data as unknown as Device[]) ?? [];
-  const [surveys] = useState<Survey[]>([]);
+  const surveys: Survey[] = surveyMastersResp?.data ?? [];
   const [searchTerm, setSearchTerm] = useState("");
   const [statusFilter, setStatusFilter] = useState<string>("ALL");
   const [isDialogOpen, setIsDialogOpen] = useState(false);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -783,12 +783,23 @@ class ApiClient {
 
   async getDevice(id: string): Promise<ApiResponse<Device>> {
     try {
-      return await this.request<ApiResponse<Device>>(`/devices/${id}`);
+      try {
+        return await this.request<ApiResponse<Device>>(`/Device/${id}`);
+      } catch (primaryError) {
+        try {
+          return await this.request<ApiResponse<Device>>(`/devices/${id}`);
+        } catch (secondaryError) {
+          const device = mockDevices.find(d => d.id === id);
+          if (!device) {
+            throw secondaryError;
+          }
+          return createMockApiResponse(device);
+        }
+      }
     } catch (error) {
-      // Fallback to mock data
       const device = mockDevices.find(d => d.id === id);
       if (!device) {
-        throw new Error(`Device with id ${id} not found`);
+        throw error;
       }
       return createMockApiResponse(device);
     }


### PR DESCRIPTION
## Purpose

Implement API integration for the "Assign Device to Survey" popup functionality. The user requested to populate the device dropdown using the `/api/Device` endpoint, the survey dropdown using the `/api/SurveyMaster` endpoint, and enable form submission through the `/api/DeviceAssignments` endpoint.

## Code changes

- **DeviceAssignmentPanel.tsx**: Added `useSurveyMasters` hook to fetch survey data from API instead of using empty state array
- **api.ts**: Updated device API methods to use uppercase `/Device` endpoint as primary with fallback to lowercase `/devices` for backward compatibility
- **Type imports**: Updated device type import path for consistency
- **Error handling**: Enhanced error handling with primary/fallback endpoint strategy and improved mock data fallbacksTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 26`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5ef3b8d4f9e74f9fbce6ebb73f356960/glow-forge)

👀 [Preview Link](https://5ef3b8d4f9e74f9fbce6ebb73f356960-glow-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5ef3b8d4f9e74f9fbce6ebb73f356960</projectId>-->
<!--<branchName>glow-forge</branchName>-->