### PR TITLE
Switch Device Status to DeviceLog API and hide instrument menu

### DIFF
--- a/src/components/DeviceStatus.tsx
+++ b/src/components/DeviceStatus.tsx
@@ -39,7 +39,7 @@ import {
 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { LeafletMap } from "@/components/LeafletMap";
-import { useDevices } from "@/hooks/useApiQueries";
+import { useDeviceLogs } from "@/hooks/useApiQueries";
 import { Device } from "@/lib/api";
 
 interface ExtendedDevice extends Omit<Device, 'surveyor'> {
@@ -63,7 +63,7 @@ export const DeviceStatus = () => {
     isLoading,
     error,
     refetch,
-  } = useDevices({ limit: 100 });
+  } = useDeviceLogs({ limit: 100 });
 
   // Transform API data to match component interface
   const devices: ExtendedDevice[] = useMemo(() => {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -158,7 +158,7 @@ export const Sidebar = ({
   };
 
   const menuItems = userRole === "survey" ? surveyMenuItems : adminManagerMenuItems;
-  const filteredItems = menuItems.filter((item) => item.roles.includes(userRole));
+  const filteredItems = menuItems.filter((item) => item.roles.includes(userRole) && item.id !== "instrument-list");
 
   const handleTabChange = (tabId: string) => {
     onTabChange(tabId);

--- a/src/hooks/useApiQueries.ts
+++ b/src/hooks/useApiQueries.ts
@@ -15,6 +15,7 @@ import type { DeviceAssignment } from "@/types/admin";
 // Query keys
 export const QUERY_KEYS = {
   devices: "devices",
+  deviceLogs: "deviceLogs",
   device: "device",
   pipelines: "pipelines",
   pipeline: "pipeline",
@@ -52,6 +53,14 @@ export function useDevices(params?: {
     queryKey: [QUERY_KEYS.devices, params],
     queryFn: () => apiClient.getDevices(params),
     staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+}
+
+export function useDeviceLogs(params?: { page?: number; limit?: number; status?: string; }) {
+  return useQuery({
+    queryKey: [QUERY_KEYS.deviceLogs, params],
+    queryFn: () => apiClient.getDeviceLogs(params),
+    staleTime: 60 * 1000,
   });
 }
 


### PR DESCRIPTION
## Purpose
Update the Device Status Grid to use the new DeviceLog API endpoint (`https://localhost:7215/api/DeviceLog`) instead of the existing devices endpoint, and hide the instrument list menu item from the sidebar navigation.

## Code changes
- **DeviceStatus component**: Replaced `useDevices` hook with `useDeviceLogs` hook to fetch data from the new API endpoint
- **API client**: Added new `getDeviceLogs()` method that calls the `/DeviceLog` endpoint with comprehensive data mapping and fallback to devices endpoint if unavailable
- **Query hooks**: Added `useDeviceLogs` hook with proper query key and caching configuration
- **Sidebar navigation**: Updated menu filtering logic to exclude the "instrument-list" menu item from all user rolesTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 42`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5ef3b8d4f9e74f9fbce6ebb73f356960/quantum-verse)

👀 [Preview Link](https://5ef3b8d4f9e74f9fbce6ebb73f356960-quantum-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5ef3b8d4f9e74f9fbce6ebb73f356960</projectId>-->
<!--<branchName>quantum-verse</branchName>-->