### PR TITLE
Add surveyId parameter to DeviceLog API with global state

### DIFF
--- a/src/hooks/useApiQueries.ts
+++ b/src/hooks/useApiQueries.ts
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import React from "react";
 import {
   apiClient,
   Device,

--- a/src/hooks/useApiQueries.ts
+++ b/src/hooks/useApiQueries.ts
@@ -11,6 +11,7 @@ import {
 } from "../lib/api";
 import { extendPipelines, withLegacyProperties } from "../lib/pipelineUtils";
 import type { DeviceAssignment } from "@/types/admin";
+import { useSurveyContext } from "@/contexts/SurveyContext";
 
 // Query keys
 export const QUERY_KEYS = {
@@ -56,10 +57,25 @@ export function useDevices(params?: {
   });
 }
 
-export function useDeviceLogs(params?: { page?: number; limit?: number; status?: string; }) {
+export function useDeviceLogs(params?: { page?: number; limit?: number; status?: string; surveyId?: string; }) {
+  const { currentSurvey } = useSurveyContext();
+  const effectiveParams = React.useMemo(() => {
+    const storedSurveyId = (() => {
+      try {
+        return (typeof localStorage !== "undefined" && localStorage.getItem("activeSurveyId")) || undefined;
+      } catch {
+        return undefined;
+      }
+    })();
+    return {
+      ...params,
+      surveyId: params?.surveyId ?? currentSurvey?.id ?? storedSurveyId,
+    };
+  }, [params?.page, params?.limit, params?.status, params?.surveyId, currentSurvey?.id]);
+
   return useQuery({
-    queryKey: [QUERY_KEYS.deviceLogs, params],
-    queryFn: () => apiClient.getDeviceLogs(params),
+    queryKey: [QUERY_KEYS.deviceLogs, effectiveParams],
+    queryFn: () => apiClient.getDeviceLogs(effectiveParams),
     staleTime: 60 * 1000,
   });
 }


### PR DESCRIPTION
## Purpose

The user requested to pass `surveyId` to the DeviceLog API endpoint (`https://localhost:7215/api/DeviceLog`) by storing the active survey dropdown selection globally and using it throughout the project. This enables filtering device logs by the currently selected survey.

## Code changes

- **SurveyContext**: Enhanced survey context to persist selected survey in localStorage and automatically restore it on page load
- **useApiQueries**: Modified `useDeviceLogs` hook to automatically include `surveyId` parameter from current survey context or localStorage
- **API Client**: Updated `getDeviceLogs` method to accept and pass `surveyId` parameter to the DeviceLog endpoint with fallback to stored survey ID
- **Persistence**: Added localStorage integration to maintain survey selection across browser sessionsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 50`

🔗 [Edit in Builder.io](https://builder.io/app/projects/580b06eb7c664358bcd1a058d01b074b/pulse-space)

👀 [Preview Link](https://580b06eb7c664358bcd1a058d01b074b-pulse-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>580b06eb7c664358bcd1a058d01b074b</projectId>-->
<!--<branchName>pulse-space</branchName>-->