### PR TITLE
Fix session persistence to prevent redirect on page refresh

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -27,6 +27,26 @@ const Index = () => {
   const [activeTab, setActiveTab] = useState("");
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
+  // Restore auth state from session on initial load
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem("currentUser");
+      if (raw) {
+        const user = JSON.parse(raw);
+        const roleFromServer = (user?.role as string) || "SURVEY_MANAGER";
+        let appRole: "admin" | "manager" | "survey" = "survey";
+        if (roleFromServer === "ADMIN") appRole = "admin";
+        else if (roleFromServer === "MANAGER") appRole = "manager";
+        else appRole = "survey";
+        setUserRole(appRole);
+        setIsAuthenticated(true);
+        setActiveTab((appRole === "survey") ? "survey-dashboard" : "dashboard");
+      }
+    } catch {
+      // ignore parse errors and treat as logged out
+    }
+  }, []);
+
   // Handle URL parameters for tab switching
   useEffect(() => {
     const tabParam = searchParams.get("tab");
@@ -45,6 +65,9 @@ const Index = () => {
   };
 
   const handleLogout = () => {
+    try {
+      sessionStorage.removeItem("currentUser");
+    } catch {}
     setIsAuthenticated(false);
     setActiveTab("");
   };


### PR DESCRIPTION
## Purpose
Fix the issue where authenticated survey managers are redirected to the login page when refreshing any page after successful login. The user reported that while login and navigation work properly, page refreshes lose the authentication state.

## Code changes
- Added `useEffect` hook to restore authentication state from `sessionStorage` on component mount
- Implemented user role parsing and mapping from server roles (ADMIN, MANAGER, SURVEY_MANAGER) to app roles (admin, manager, survey)
- Set appropriate default tab based on user role on session restoration
- Added session cleanup in logout handler to properly remove stored user data
- Added error handling for JSON parsing and sessionStorage operationsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 51`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2c87f765ec49494dbcac86b40508c58b/spark-lab)

👀 [Preview Link](https://2c87f765ec49494dbcac86b40508c58b-spark-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2c87f765ec49494dbcac86b40508c58b</projectId>-->
<!--<branchName>spark-lab</branchName>-->