### PR TITLE
Fix null API response handling with array type checks

### DIFF
--- a/src/components/CatastropheManagement.tsx
+++ b/src/components/CatastropheManagement.tsx
@@ -58,7 +58,7 @@ const CatastropheManagement = () => {
 
   // Transform API data to component format
   const catastrophes = useMemo(() => {
-    if (!catastrophesResponse?.data) return [];
+    if (!Array.isArray(catastrophesResponse?.data)) return [];
 
     return catastrophesResponse.data.map(
       (cat: APICatastrophe): Catastrophe => ({
@@ -137,7 +137,7 @@ const CatastropheManagement = () => {
 
   // Transform API data for map
   const mapDevices = useMemo(() => {
-    if (!devicesResponse?.data) return [];
+    if (!Array.isArray(devicesResponse?.data)) return [];
     return devicesResponse.data.map((device) => ({
       id: device.id,
       name: device.name,
@@ -152,7 +152,7 @@ const CatastropheManagement = () => {
   }, [devicesResponse]);
 
   const mapPipelines = useMemo(() => {
-    if (!pipelinesResponse?.data) return [];
+    if (!Array.isArray(pipelinesResponse?.data)) return [];
     return pipelinesResponse.data.map((pipeline) => ({
       id: pipeline.id,
       diameter: pipeline.diameter,
@@ -169,7 +169,7 @@ const CatastropheManagement = () => {
   }, [pipelinesResponse]);
 
   const mapValves = useMemo(() => {
-    if (!valvesResponse?.data) return [];
+    if (!Array.isArray(valvesResponse?.data)) return [];
     return valvesResponse.data.map((valve) => ({
       id: valve.id,
       type:

--- a/src/components/DeviceStatus.tsx
+++ b/src/components/DeviceStatus.tsx
@@ -67,7 +67,7 @@ export const DeviceStatus = () => {
 
   // Transform API data to match component interface
   const devices: ExtendedDevice[] = useMemo(() => {
-    if (!devicesResponse?.data) return [];
+    if (!Array.isArray(devicesResponse?.data)) return [];
 
     return devicesResponse.data.map((device) => ({
       ...device,

--- a/src/hooks/useApiQueries.ts
+++ b/src/hooks/useApiQueries.ts
@@ -53,7 +53,11 @@ export function useDevices(params?: {
 }) {
   return useQuery({
     queryKey: [QUERY_KEYS.devices, params],
-    queryFn: () => apiClient.getDevices(params),
+    queryFn: async () => {
+      const response = await apiClient.getDevices(params);
+      const items = Array.isArray(response?.data) ? response.data : [];
+      return { ...response, data: items };
+    },
     staleTime: 5 * 60 * 1000, // 5 minutes
   });
 }
@@ -204,7 +208,11 @@ export function useValves(params?: {
 }) {
   return useQuery({
     queryKey: [QUERY_KEYS.valves, params],
-    queryFn: () => apiClient.getValves(params),
+    queryFn: async () => {
+      const response = await apiClient.getValves(params);
+      const items = Array.isArray(response?.data) ? response.data : [];
+      return { ...response, data: items };
+    },
     staleTime: 5 * 60 * 1000,
   });
 }
@@ -259,7 +267,11 @@ export function useCatastrophes(params?: {
 }) {
   return useQuery({
     queryKey: [QUERY_KEYS.catastrophes, params],
-    queryFn: () => apiClient.getCatastrophes(params),
+    queryFn: async () => {
+      const response = await apiClient.getCatastrophes(params);
+      const items = Array.isArray(response?.data) ? response.data : [];
+      return { ...response, data: items };
+    },
     staleTime: 2 * 60 * 1000, // 2 minutes for more real-time updates
   });
 }
@@ -460,7 +472,11 @@ export function useValveOperations(params?: {
 }) {
   return useQuery({
     queryKey: [QUERY_KEYS.valveOperations, params],
-    queryFn: () => apiClient.getValveOperations(params),
+    queryFn: async () => {
+      const response = await apiClient.getValveOperations(params);
+      const items = Array.isArray(response?.data) ? response.data : [];
+      return { ...response, data: items };
+    },
   });
 }
 

--- a/src/hooks/useApiQueries.ts
+++ b/src/hooks/useApiQueries.ts
@@ -133,9 +133,10 @@ export function usePipelines(params?: {
     queryKey: [QUERY_KEYS.pipelines, params],
     queryFn: async () => {
       const response = await apiClient.getPipelines(params);
+      const items = Array.isArray(response?.data) ? response.data : [];
       return {
         ...response,
-        data: extendPipelines(response.data)
+        data: extendPipelines(items)
       };
     },
     staleTime: 5 * 60 * 1000,

--- a/src/hooks/useValveOperations.ts
+++ b/src/hooks/useValveOperations.ts
@@ -26,11 +26,11 @@ export const useValveOperations = () => {
 
   // Transform API data to component format
   const operations: ValveOperation[] = useMemo(() => {
-    if (!operationsResponse?.data) return [];
+    if (!Array.isArray(operationsResponse?.data)) return [];
 
     return operationsResponse.data.map((op) => ({
       id: op.id,
-      catastropheId: "CATASTROPHE_001", // Map based on your business logic
+      catastropheId: "CATASTROPHE_001",
       valveId: op.valveId,
       actionType: op.operation === "OPEN" ? "open" : "close",
       actionTimestamp: new Date(op.timestamp),
@@ -40,7 +40,7 @@ export const useValveOperations = () => {
   }, [operationsResponse]);
 
   const valves: Valve[] = useMemo(() => {
-    if (!valvesResponse?.data) return [];
+    if (!Array.isArray(valvesResponse?.data)) return [];
 
     return valvesResponse.data.map((valve) => ({
       id: valve.id,
@@ -58,7 +58,7 @@ export const useValveOperations = () => {
   }, [valvesResponse]);
 
   const catastrophes: Catastrophe[] = useMemo(() => {
-    if (!catastrophesResponse?.data) return [];
+    if (!Array.isArray(catastrophesResponse?.data)) return [];
 
     return catastrophesResponse.data.map((cat) => ({
       id: cat.id,

--- a/src/lib/pipelineUtils.ts
+++ b/src/lib/pipelineUtils.ts
@@ -137,12 +137,14 @@ export function withLegacyProperties(pipeline: PipelineSegment): PipelineSegment
 }
 
 // Utility function to convert array of pipelines to legacy format
-export function toLegacyPipelines(pipelines: PipelineSegment[]): LegacyPipelineSegment[] {
+export function toLegacyPipelines(pipelines?: PipelineSegment[] | null): LegacyPipelineSegment[] {
+  if (!Array.isArray(pipelines)) return [];
   return pipelines.map(p => PipelineAdapter.from(p).toLegacy());
 }
 
 // Utility function to get legacy-compatible pipeline list with extended properties
-export function extendPipelines(pipelines: PipelineSegment[]): (PipelineSegment & LegacyPipelineSegment)[] {
+export function extendPipelines(pipelines?: PipelineSegment[] | null): (PipelineSegment & LegacyPipelineSegment)[] {
+  if (!Array.isArray(pipelines)) return [];
   return pipelines.map(withLegacyProperties);
 }
 

--- a/src/pages/PipelineOperations.tsx
+++ b/src/pages/PipelineOperations.tsx
@@ -285,7 +285,7 @@ export const PipelineOperations = () => {
 
   // Transform data for components
   const mapDevices = useMemo(() => {
-    if (!devicesResponse?.data) return [];
+    if (!Array.isArray(devicesResponse?.data)) return [];
     return devicesResponse.data.map((device) => ({
       id: device.id,
       name: device.name,
@@ -297,18 +297,18 @@ export const PipelineOperations = () => {
   }, [devicesResponse]);
 
   const mapPipelines = useMemo(() => {
-    if (!pipelinesResponse?.data) return [];
+    if (!Array.isArray(pipelinesResponse?.data)) return [];
     return pipelinesResponse.data.map((pipeline) => ({
       id: pipeline.id,
       diameter: pipeline.specifications?.diameter?.value || 200,
       depth: pipeline.installation?.depth?.value || 1.5,
-      status: pipeline.status === "OPERATIONAL" ? "normal" : 
+      status: pipeline.status === "OPERATIONAL" ? "normal" :
               pipeline.status === "MAINTENANCE" ? "warning" : "critical",
     }));
   }, [pipelinesResponse]);
 
   const mapValves = useMemo(() => {
-    if (!valvesResponse?.data) return [];
+    if (!Array.isArray(valvesResponse?.data)) return [];
     return valvesResponse.data.map((valve) => ({
       id: valve.id,
       type: valve.type === "GATE" ? "control" : valve.type === "RELIEF" ? "emergency" : "isolation",
@@ -318,7 +318,7 @@ export const PipelineOperations = () => {
   }, [valvesResponse]);
 
   const catastrophes = useMemo(() => {
-    if (!catastrophesResponse?.data) return [];
+    if (!Array.isArray(catastrophesResponse?.data)) return [];
     return catastrophesResponse.data.map((cat) => ({
       id: cat.id,
       segmentId: cat.pipelineId || "Unknown",
@@ -333,7 +333,7 @@ export const PipelineOperations = () => {
   }, [catastrophesResponse]);
 
   const valveOperations = useMemo(() => {
-    if (!valveOperationsResponse?.data) return [];
+    if (!Array.isArray(valveOperationsResponse?.data)) return [];
     return valveOperationsResponse.data.map((op) => ({
       id: op.id,
       valveId: op.valveId,
@@ -346,8 +346,8 @@ export const PipelineOperations = () => {
   }, [valveOperationsResponse]);
 
   // Table configurations
-  const pipelineTable = useTable(pipelinesResponse?.data || [], 10, "id");
-  const valveTable = useTable(valvesResponse?.data || [], 10, "id");
+  const pipelineTable = useTable(Array.isArray(pipelinesResponse?.data) ? pipelinesResponse.data : [], 10, "id");
+  const valveTable = useTable(Array.isArray(valvesResponse?.data) ? valvesResponse.data : [], 10, "id");
   const catastropheTable = useTable(catastrophes, 10, "id");
   const operationTable = useTable(valveOperations, 10, "id");
 


### PR DESCRIPTION
## Purpose

The user reported that the pipelines API endpoint (`https://localhost:7215/api/pipelines?limit=100`) can return null values, which was causing application errors. The goal was to handle null data gracefully without throwing errors when the API returns null instead of an expected array.

## Code changes

- **Enhanced null checks**: Replaced simple truthiness checks (`!data`) with explicit array type validation (`!Array.isArray(data)`) across all API response handlers
- **API query functions**: Updated `useDevices`, `usePipelines`, `useValves`, `useCatastrophes`, and `useValveOperations` hooks to normalize null/non-array responses to empty arrays
- **Component data transformations**: Modified data transformation logic in `CatastropheManagement`, `DeviceStatus`, `PipelineOperations`, and `useValveOperations` to use array type checks
- **Utility functions**: Updated `toLegacyPipelines` and `extendPipelines` functions to handle null/undefined inputs safely
- **Table configurations**: Added array type validation for table data initialization

These changes ensure that when APIs return null or non-array values, the application gracefully defaults to empty arrays instead of throwing runtime errors.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 61`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2c87f765ec49494dbcac86b40508c58b/zen-home)

👀 [Preview Link](https://2c87f765ec49494dbcac86b40508c58b-zen-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2c87f765ec49494dbcac86b40508c58b</projectId>-->
<!--<branchName>zen-home</branchName>-->