### PR TITLE
Rename Device Status to Instrument List and remove static menu normalization

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -69,12 +69,6 @@ const adminManagerMenuItems: MenuItem[] = [
     roles: ["admin", "manager"],
   },
   {
-    id: "instrument-list",
-    label: "Instrument List",
-    icon: Users,
-    roles: ["admin", "manager"],
-  },
-  {
     id: "heatmap-view",
     label: "Heatmap View",
     icon: Map,
@@ -118,12 +112,6 @@ const surveyMenuItems: MenuItem[] = [
     id: "survey-dashboard",
     label: "Dashboard",
     icon: Monitor,
-    roles: ["survey"],
-  },
-  {
-    id: "instrument-list",
-    label: "Instrument List",
-    icon: Users,
     roles: ["survey"],
   },
   {
@@ -203,13 +191,7 @@ export const Sidebar = ({
   // Build dynamic asset menus from AssetTypes API
   const [assetMenus, setAssetMenus] = useState<Array<{ id: string; label: string; icon: any; order: number; path: string }>>([]);
 
-  const normalizeHeading = (name: string) => {
-    const n = name.trim().toLowerCase();
-    if (n === "pipeline" || n === "pipe") return "Pipeline Network";
-    if (n === "valve") return "Valve Points";
-    if (n.includes("catastrophe")) return "Catastrophe Management";
-    return name;
-  };
+  const normalizeHeading = (name: string) => name;
 
   useEffect(() => {
     let mounted = true;
@@ -361,7 +343,13 @@ export const Sidebar = ({
               onClick={onClick}
             >
               <Icon className={cn("h-4 w-4", !isCollapsed && "mr-3")} />
-              {!isCollapsed && <span className="text-sm font-medium">{item.label}</span>}
+              {!isCollapsed && (
+                <span className="text-sm font-medium">
+                  {item.id === "devices"
+                    ? (userRole === "admin" ? "Device Status" : "Instrument List")
+                    : item.label}
+                </span>
+              )}
             </Button>
           );
         })}

--- a/src/pages/AssetMenus.tsx
+++ b/src/pages/AssetMenus.tsx
@@ -11,13 +11,7 @@ interface AssetTypeItem {
   menuName: string | null;
 }
 
-const normalizeHeading = (name: string) => {
-  const n = name.trim().toLowerCase();
-  if (n === "pipeline") return "Pipeline Network";
-  if (n === "valve") return "Valve Points";
-  if (n === "catastrophe" || n === "catastrophe management") return "Catastrophe Management";
-  return name;
-};
+const normalizeHeading = (name: string) => name;
 
 export default function AssetMenus() {
   const { menu } = useParams<{ menu: string }>();

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -13,8 +13,6 @@ import CatastropheManagement from "@/components/CatastropheManagement";
 import ValveOperationLog from "@/components/ValveOperationLog";
 import { ReportsDashboard } from "@/components/ReportsDashboard";
 import { SurveyDashboard } from "@/components/survey/Dashboard";
-import { InstrumentList } from "@/components/survey/InstrumentList";
-import { InstrumentDetail } from "@/components/survey/InstrumentDetail";
 import { HeatmapView } from "@/components/survey/HeatmapView";
 import { AlertsNotifications } from "@/components/survey/AlertsNotifications";
 import { SurveyReports } from "@/components/survey/SurveyReports";
@@ -82,10 +80,6 @@ const Index = () => {
           return <DailyPersonalMaps />;
         case "survey-dashboard":
           return <SurveyDashboard />;
-        case "instrument-list":
-          return <InstrumentList />;
-        case "instrument-detail":
-          return <InstrumentDetail onBack={() => setActiveTab("instrument-list")} />;
         case "heatmap-view":
           return <HeatmapView />;
         case "alerts-notifications":
@@ -105,8 +99,6 @@ const Index = () => {
         return <DeviceStatus />;
       case "daily-maps":
         return <DailyPersonalMaps />;
-      case "instrument-list":
-        return <InstrumentList />;
       case "heatmap-view":
         return <HeatmapView />;
       case "alerts-notifications":


### PR DESCRIPTION
## Purpose

The user requested to rename the "Device Status" menu to "Instrument List" in the manager login interface and remove the standalone Instrument List page. Additionally, they wanted dynamic menus like "Valve Points" and "Pipeline Network" to use API-returned menu names instead of hardcoded normalized names.

## Code changes

- **Menu renaming**: Updated sidebar to conditionally display "Device Status" for admin users and "Instrument List" for manager users on the devices menu item
- **Removed Instrument List page**: Eliminated the standalone "instrument-list" menu items from both admin/manager and survey menu configurations
- **Removed static menu normalization**: Replaced the `normalizeHeading` function with a simple pass-through function that returns the original name, allowing dynamic menus to use API-provided names
- **Cleaned up routing**: Removed instrument list and detail page routing from the main Index component
- **Removed imports**: Cleaned up unused InstrumentList and InstrumentDetail component imports

The changes ensure that menu names are now dynamically controlled by the API response rather than being hardcoded, while maintaining the appropriate menu structure for different user roles.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 74`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ef8527e0ad8142efb8fd3d5f3836935d/vibe-lab)

👀 [Preview Link](https://ef8527e0ad8142efb8fd3d5f3836935d-vibe-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ef8527e0ad8142efb8fd3d5f3836935d</projectId>-->
<!--<branchName>vibe-lab</branchName>-->