### PR TITLE
Add instrument buttons and hide daily maps menu

### DIFF
--- a/src/components/DeviceStatus.tsx
+++ b/src/components/DeviceStatus.tsx
@@ -494,6 +494,7 @@ export const DeviceStatus = () => {
                 >
                   Accuracy
                 </SortableTableHead>
+                <TableHead>Actions</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -582,6 +583,11 @@ export const DeviceStatus = () => {
                   </TableCell>
                   <TableCell>
                     {typeof device.accuracy === "number" ? device.accuracy.toFixed(2) : "N/A"}
+                  </TableCell>
+                  <TableCell>
+                    <Button size="sm" onClick={() => navigate(`/daily-personal-maps?device=${encodeURIComponent(device.id)}`)}>
+                      Instrument
+                    </Button>
                   </TableCell>
                 </TableRow>
               ))}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -161,6 +161,7 @@ export const Sidebar = ({
       item.id !== "pipeline-editor" &&
       item.id !== "valve-editor" &&
       item.id !== "catastrophe" &&
+      item.id !== "daily-maps" &&
       item.id !== "heatmap-view"
   );
 

--- a/src/components/survey/InstrumentList.tsx
+++ b/src/components/survey/InstrumentList.tsx
@@ -6,11 +6,13 @@ import { Badge } from "@/components/ui/badge";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Search, Download, Eye, Battery, Wifi, WifiOff } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 
 export const InstrumentList = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
   const [locationFilter, setLocationFilter] = useState("all");
+  const navigate = useNavigate();
 
   // Mock data - replace with actual API calls
   const instruments = [
@@ -197,9 +199,14 @@ export const InstrumentList = () => {
                     <TableCell>{getHealthBadge(instrument.healthStatus)}</TableCell>
                     <TableCell>{instrument.totalUsage}</TableCell>
                     <TableCell>
-                      <Button variant="ghost" size="sm">
-                        <Eye className="w-4 h-4" />
-                      </Button>
+                      <div className="flex items-center gap-2">
+                        <Button variant="ghost" size="sm">
+                          <Eye className="w-4 h-4" />
+                        </Button>
+                        <Button size="sm" onClick={() => navigate(`/daily-personal-maps?device=${encodeURIComponent(instrument.id)}`)}>
+                          Instrument
+                        </Button>
+                      </div>
                     </TableCell>
                   </TableRow>
                 ))}

--- a/src/pages/AssetMenus.tsx
+++ b/src/pages/AssetMenus.tsx
@@ -103,9 +103,6 @@ export default function AssetMenus() {
           <div className="p-6">
             <div className="flex items-center justify-between mb-4">
               <div className="h-6 w-64 bg-muted animate-pulse rounded" />
-              <Button asChild variant="ghost" disabled>
-                <span className="flex items-center"><ArrowLeft className="h-4 w-4 mr-2" />Back</span>
-              </Button>
             </div>
             <div className="h-[600px] bg-muted animate-pulse rounded" />
           </div>
@@ -129,9 +126,6 @@ export default function AssetMenus() {
         <div className="p-6 space-y-4">
           <div className="flex items-center justify-between">
             <h1 className="text-3xl font-bold">{heading}</h1>
-            <Button asChild variant="ghost" onClick={() => window.history.back()}>
-              <span className="flex items-center"><ArrowLeft className="h-4 w-4 mr-2" />Back</span>
-            </Button>
           </div>
           {key === "pipeline" && <PipelineNetworkEditor />}
           {key === "valve" && <ValvePointsEditor />}

--- a/src/pages/AssetMenus.tsx
+++ b/src/pages/AssetMenus.tsx
@@ -1,12 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
-import { useParams, Link, useNavigate } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { ValvePointsEditor } from "@/components/ValvePointsEditor";
 import { PipelineNetworkEditor } from "@/components/PipelineNetworkEditor";
 import CatastropheManagement from "@/components/CatastropheManagement";
 import apiClient from "@/lib/api";
-import { Button } from "@/components/ui/button";
-import { ArrowLeft } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
 import { Sidebar } from "@/components/Sidebar";
 
 interface AssetTypeItem {


### PR DESCRIPTION
## Purpose

The user requested UI improvements to streamline navigation and add instrument functionality. They wanted to remove back buttons from specific management pages, add instrument buttons to device/instrument grids, and hide the "Daily Personal Map" menu from the sidebar while linking it through the new instrument buttons.

## Code changes

- **Added "Actions" column** to DeviceStatus and InstrumentList tables with "Instrument" buttons
- **Removed back buttons** from Valve, Pipeline, and Catastrophe Management pages
- **Hidden "Daily Personal Map" menu** from sidebar by filtering out "daily-maps" item
- **Added navigation functionality** to instrument buttons that route to daily personal maps with device ID parameter
- **Updated imports** to include useNavigate hook for routing functionalityTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 79`

🔗 [Edit in Builder.io](https://builder.io/app/projects/400ce1159faa4246aa16415ab72ad693/orbit-field)

👀 [Preview Link](https://400ce1159faa4246aa16415ab72ad693-orbit-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>400ce1159faa4246aa16415ab72ad693</projectId>-->
<!--<branchName>orbit-field</branchName>-->