### PR TITLE
Hide specific menu items based on user role permissions

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -153,17 +153,24 @@ export const Sidebar = ({
   };
 
   const menuItems = userRole === "survey" ? surveyMenuItems : adminManagerMenuItems;
-  const filteredItems = menuItems.filter(
-    (item) =>
-      item.roles.includes(userRole) &&
-      item.id !== "pipeline-operations" &&
-      item.id !== "valve-operations" &&
-      item.id !== "pipeline-editor" &&
-      item.id !== "valve-editor" &&
-      item.id !== "catastrophe" &&
-      item.id !== "daily-maps" &&
-      item.id !== "heatmap-view"
-  );
+  const filteredItems = menuItems.filter((item) => {
+    if (!item.roles.includes(userRole)) return false;
+    if (
+      item.id === "pipeline-operations" ||
+      item.id === "valve-operations" ||
+      item.id === "pipeline-editor" ||
+      item.id === "valve-editor" ||
+      item.id === "catastrophe" ||
+      item.id === "daily-maps" ||
+      item.id === "heatmap-view"
+    ) {
+      return false;
+    }
+    if (userRole === "manager" && (item.id === "alerts-notifications" || item.id === "reports")) {
+      return false;
+    }
+    return true;
+  });
 
   const handleTabChange = (tabId: string) => {
     onTabChange(tabId);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -229,7 +229,14 @@ export const Sidebar = ({
     return () => { mounted = false; };
   }, []);
 
-  const combinedItems: Array<any> = [...filteredItems, ...assetMenus];
+  const filteredAssetMenus = assetMenus.filter((m) => {
+    if (userRole === "survey") {
+      return m.id !== "assets:pipeline" && m.id !== "assets:valve" && m.id !== "assets:catastrophe";
+    }
+    return true;
+  });
+
+  const combinedItems: Array<any> = [...filteredItems, ...filteredAssetMenus];
 
   return (
     <div


### PR DESCRIPTION
## Purpose

This change implements role-based menu filtering to hide specific navigation items from different user types. The goal is to restrict access to certain features based on user permissions - hiding valve, pipeline, and catastrophe menus from survey-manager users, and hiding alerts & notifications and reports menus from manager users.

## Code changes

- **Enhanced menu filtering logic**: Refactored the `filteredItems` logic in `Sidebar.tsx` to use a more structured conditional approach
- **Added manager role restrictions**: Implemented filtering to hide "alerts-notifications" and "reports" menu items for users with "manager" role
- **Added survey role asset menu filtering**: Created `filteredAssetMenus` to hide pipeline, valve, and catastrophe asset menus from "survey" role users
- **Improved code structure**: Replaced inline filter conditions with a clearer conditional block structure for better maintainabilityTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 81`

🔗 [Edit in Builder.io](https://builder.io/app/projects/400ce1159faa4246aa16415ab72ad693/mystic-landing)

👀 [Preview Link](https://400ce1159faa4246aa16415ab72ad693-mystic-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>400ce1159faa4246aa16415ab72ad693</projectId>-->
<!--<branchName>mystic-landing</branchName>-->