### PR TITLE
Conditionally show Add Catastrophe button based on API response

### DIFF
--- a/src/components/CatastropheManagement.tsx
+++ b/src/components/CatastropheManagement.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -20,7 +20,7 @@ import {
   useCreateCatastrophe,
   useUpdateCatastrophe,
 } from "@/hooks/useApiQueries";
-import { Catastrophe as APICatastrophe } from "@/lib/api";
+import apiClient, { Catastrophe as APICatastrophe } from "@/lib/api";
 import { toast } from "sonner";
 
 export interface Catastrophe {
@@ -79,6 +79,34 @@ const CatastropheManagement = () => {
   const [showForm, setShowForm] = useState(false);
   const [editingCatastrophe, setEditingCatastrophe] =
     useState<Catastrophe | null>(null);
+  const [showAddButton, setShowAddButton] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const res = await apiClient.getAssetTypes({ limit: 50 });
+        const items = Array.isArray(res?.data) ? res.data : [];
+        const catastropheType = items.find((a) => {
+          const name = (a.name || "").toLowerCase();
+          const menu = (a.menuName || "").toLowerCase();
+          return name === "catastrophe" || menu.includes("catastrophe");
+        });
+        if (mounted) {
+          if (catastropheType) {
+            setShowAddButton(!catastropheType.isSurveyElement);
+          } else {
+            // If not found, keep the button visible as earlier
+            setShowAddButton(true);
+          }
+        }
+      } catch {
+        // On API error, preserve previous behavior (show the button)
+        if (mounted) setShowAddButton(true);
+      }
+    })();
+    return () => { mounted = false; };
+  }, []);
 
   const handleAddNew = () => {
     setEditingCatastrophe(null);
@@ -223,10 +251,12 @@ const CatastropheManagement = () => {
             />
             {isLoading ? "Loading..." : "Refresh"}
           </Button>
-          <Button onClick={handleAddNew} className="gap-2">
-            <Plus className="h-4 w-4" />
-            Add Catastrophe
-          </Button>
+          {showAddButton && (
+            <Button onClick={handleAddNew} className="gap-2">
+              <Plus className="h-4 w-4" />
+              Add Catastrophe
+            </Button>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Purpose
Restore the Add Catastrophe button visibility in the Catastrophe Management page based on the `isSurveyElement` property from the AssetTypes API endpoint. The button should only be shown when `isSurveyElement` is `false` for the catastrophe asset type.

## Code changes
- Added `useEffect` hook to fetch asset types from `/api/AssetTypes?limit=50` endpoint
- Implemented logic to find catastrophe-related asset type by name or menu name
- Added `showAddButton` state that controls Add Catastrophe button visibility
- Button is hidden when `isSurveyElement` is `true`, shown when `false` or on API errors
- Wrapped the Add Catastrophe button with conditional rendering based on `showAddButton` state
- Added proper cleanup with mounted flag to prevent state updates on unmounted componentsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 83`

🔗 [Edit in Builder.io](https://builder.io/app/projects/146a819938a1491ebb445283a5eaa348/quantum-nest)

👀 [Preview Link](https://146a819938a1491ebb445283a5eaa348-quantum-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>146a819938a1491ebb445283a5eaa348</projectId>-->
<!--<branchName>quantum-nest</branchName>-->