### PR TITLE
Fix pipeline page loading by using real data in map

### DIFF
--- a/src/components/PipelineNetworkEditor.tsx
+++ b/src/components/PipelineNetworkEditor.tsx
@@ -483,12 +483,12 @@ export const PipelineNetworkEditor = () => {
           <CardContent>
             <div className="h-96">
               <LeafletMap
-                devices={demoDevices}
-                pipelines={demoPipelinesWithStatus}
-                valves={demoValves}
-                showDevices={true}
-                showPipelines={true}
-                showValves={true}
+                devices={mapDevices}
+                pipelines={mapPipelines}
+                valves={[]}
+                showDevices={showDevicesOnMap}
+                showPipelines={mapPipelines.length > 0}
+                showValves={false}
               />
             </div>
           </CardContent>

--- a/src/components/PipelineNetworkEditor.tsx
+++ b/src/components/PipelineNetworkEditor.tsx
@@ -541,10 +541,10 @@ export const PipelineNetworkEditor = () => {
               <LeafletMap
                 devices={mapDevices}
                 pipelines={mapPipelines}
-                valves={[]}
+                valves={mapValves}
                 showDevices={showDevicesOnMap}
-                showPipelines={mapPipelines.length > 0}
-                showValves={false}
+                showPipelines={showPipelinesOnMap}
+                showValves={showValvesOnMap}
               />
             </div>
           </CardContent>


### PR DESCRIPTION
## Purpose
Fix the pipeline page loading error by replacing demo data with actual pipeline data in the map component.

## Code changes
- Added `mapValves` computation to extract valve data from pipeline segments
- Replaced demo data (`demoDevices`, `demoPipelinesWithStatus`, `demoValves`) with real data (`mapDevices`, `mapPipelines`, `mapValves`) in LeafletMap component
- Added conditional visibility flags (`showDevicesOnMap`, `showPipelinesOnMap`, `showValvesOnMap`) based on actual data availability
- Implemented valve status mapping based on segment status (operational → open, maintenance → maintenance, damaged → fault, other → closed)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 88`

🔗 [Edit in Builder.io](https://builder.io/app/projects/17660aca387a483b8a2cd53a12a80574/aura-realm)

👀 [Preview Link](https://17660aca387a483b8a2cd53a12a80574-aura-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>17660aca387a483b8a2cd53a12a80574</projectId>-->
<!--<branchName>aura-realm</branchName>-->