### PR TITLE
Map Dashboard: Show Pipelines, Valves, and Consumer Points

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { Analytics } from "./pages/Analytics";
 import Admin from "./pages/Admin";
 import PipelineOperations from "./pages/PipelineOperations";
 import AssetMenus from "./pages/AssetMenus";
+import FlowlinesMapPage from "./pages/FlowlinesMapPage";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -34,6 +35,7 @@ const App = () => (
               <Route path="/survey-details" element={<SurveyDetailsPage />} />
               <Route path="/analytics" element={<Analytics />} />
               <Route path="/pipeline-operations" element={<PipelineOperations />} />
+              <Route path="/flowlines-map" element={<FlowlinesMapPage />} />
               <Route path="/assets/:menu" element={<AssetMenus />} />
               <Route path="/admin" element={<Admin />} />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import Admin from "./pages/Admin";
 import PipelineOperations from "./pages/PipelineOperations";
 import AssetMenus from "./pages/AssetMenus";
 import FlowlinesMapPage from "./pages/FlowlinesMapPage";
+import ValvesMapPage from "./pages/ValvesMapPage";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -36,6 +37,7 @@ const App = () => (
               <Route path="/analytics" element={<Analytics />} />
               <Route path="/pipeline-operations" element={<PipelineOperations />} />
               <Route path="/flowlines-map" element={<FlowlinesMapPage />} />
+              <Route path="/valves-map" element={<ValvesMapPage />} />
               <Route path="/assets/:menu" element={<AssetMenus />} />
               <Route path="/admin" element={<Admin />} />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/components/ConsumerPointsEditor.tsx
+++ b/src/components/ConsumerPointsEditor.tsx
@@ -131,7 +131,27 @@ export const ConsumerPointsEditor = () => {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="grid grid-cols-1 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Consumer Points Map</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="h-[500px]">
+              <LeafletMap
+                devices={[]}
+                pipelines={[]}
+                valves={[]}
+                consumers={mapConsumers}
+                showDevices={false}
+                showPipelines={false}
+                showValves={false}
+                showConsumers={mapConsumers.length > 0}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
@@ -204,26 +224,6 @@ export const ConsumerPointsEditor = () => {
                 pageSizeOptions={[5, 10, 20]}
               />
             )}
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Consumer Points Map</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="h-[500px]">
-              <LeafletMap
-                devices={mapDevices}
-                pipelines={[]}
-                valves={[]}
-                consumers={mapConsumers}
-                showDevices={mapDevices.length > 0}
-                showPipelines={false}
-                showValves={false}
-                showConsumers={mapConsumers.length > 0}
-              />
-            </div>
           </CardContent>
         </Card>
       </div>

--- a/src/components/ConsumerPointsEditor.tsx
+++ b/src/components/ConsumerPointsEditor.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useMemo, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { LeafletMap } from "@/components/LeafletMap";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { SortableTableHead } from "@/components/ui/sortable-table-head";
+import { Pagination } from "@/components/ui/pagination";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { MapPin, AlertTriangle, Loader2 } from "lucide-react";
+import { useTable } from "@/hooks/use-table";
+import { useDeviceLogs } from "@/hooks/useApiQueries";
+import { apiClient } from "@/lib/api";
+
+// Dynamic row type for arbitrary property names
+type DynamicRow = Record<string, any>;
+
+interface ConsumerPoint {
+  id: string;
+  name?: string;
+  code?: string;
+  mobile?: string;
+  status?: string;
+  coordinates: { lat: number; lng: number };
+}
+
+export const ConsumerPointsEditor = () => {
+  const [rows, setRows] = useState<DynamicRow[]>([]);
+  const [columns, setColumns] = useState<string[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Load consumers from survey-geojson endpoint
+  useEffect(() => {
+    const controller = new AbortController();
+    async function loadConsumers() {
+      setLoading(true);
+      setError(null);
+      try {
+        const json = await apiClient.getSurveyGeoJson("Consumer");
+        
+        let featureCollection: any = { type: "FeatureCollection", features: [] };
+        if (typeof json?.data === 'string') {
+          try {
+            featureCollection = JSON.parse(json.data);
+          } catch (e) {
+            console.error("Failed to parse GeoJSON string:", e);
+          }
+        } else if (json?.data?.type === 'FeatureCollection') {
+          featureCollection = json.data;
+        } else if (json?.type === 'FeatureCollection') {
+            featureCollection = json;
+        }
+
+        const features = Array.isArray(featureCollection?.features) ? featureCollection.features : [];
+        
+        const normalized = features.map((f: any) => ({
+          ...f.properties,
+          id: f.properties?.SE_ID || f.properties?.Consumer_Code || Math.random().toString(),
+          lat: f.geometry?.coordinates?.[1],
+          lng: f.geometry?.coordinates?.[0]
+        }));
+
+        setRows(normalized);
+        if (normalized.length > 0) {
+          // Filter out internal id or messy props if needed, but following ValvePointsEditor style
+          setColumns(Object.keys(normalized[0]));
+        }
+      } catch (e: any) {
+        setError(e?.message || "Failed to load consumer data");
+        setRows([]);
+        setColumns([]);
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadConsumers();
+    return () => controller.abort();
+  }, []);
+
+  const defaultSortKey = (columns.includes("id") ? "id" : columns[0]) as keyof DynamicRow | undefined;
+  const { tableConfig, sortedAndPaginatedData } = useTable<DynamicRow>(rows, 10, defaultSortKey as any);
+
+  // Derive map points
+  const mapConsumers: ConsumerPoint[] = useMemo(() => {
+    return rows.map((r) => ({
+      id: String(r.id || r.SE_ID || ""),
+      name: String(r.Consumer_Name || "Consumer"),
+      code: String(r.Consumer_Code || ""),
+      mobile: String(r.Mobile || ""),
+      status: String(r.SE_VALUE || ""),
+      coordinates: {
+        lat: Number(r.lat || r.CONSUMER_LAT || 0),
+        lng: Number(r.lng || r.CONSUMER_LNG || 0),
+      },
+    }));
+  }, [rows]);
+
+  // Devices from DeviceLog for context
+  const { data: deviceLogsResponse } = useDeviceLogs({ limit: 100 });
+  const mapDevices = useMemo(() => {
+    const items = Array.isArray(deviceLogsResponse?.data) ? deviceLogsResponse!.data : [];
+    return items.map((device: any) => ({
+      id: device.id,
+      name: device.name,
+      lat: Number(device.coordinates?.lat) || 0,
+      lng: Number(device.coordinates?.lng) || 0,
+      status:
+        String(device.status).toUpperCase() === "ACTIVE"
+          ? ("active" as const)
+          : String(device.status).toUpperCase() === "MAINTENANCE"
+            ? ("maintenance" as const)
+            : String(device.status).toUpperCase() === "ERROR"
+              ? ("error" as const)
+              : ("offline" as const),
+      lastPing: device.lastSeen || "Unknown",
+    }));
+  }, [deviceLogsResponse]);
+
+  return (
+    <div className="p-0 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">Consumer Points Viewer</h1>
+          <p className="text-muted-foreground">View and manage consumer survey points</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <MapPin className="h-5 w-5" />
+              Consumer Points ({rows.length})
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <div className="p-6 pb-0 overflow-x-auto">
+              {error && (
+                <Alert variant="destructive" className="mb-4">
+                  <AlertTriangle className="h-4 w-4" />
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+              {loading ? (
+                <div className="flex items-center justify-center py-8">
+                  <Loader2 className="h-8 w-8 animate-spin" />
+                  <span className="ml-2 text-sm text-muted-foreground">Loading consumers...</span>
+                </div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      {columns.length === 0 ? (
+                        <TableHead>No data</TableHead>
+                      ) : (
+                        columns.map((col) => (
+                          <SortableTableHead
+                            key={col}
+                            sortKey={col}
+                            currentSortKey={tableConfig.sortConfig.key as unknown as string}
+                            sortDirection={tableConfig.sortConfig.direction}
+                            onSort={(k) => tableConfig.handleSort(k as keyof DynamicRow)}
+                          >
+                            {col}
+                          </SortableTableHead>
+                        ))
+                      )}
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {sortedAndPaginatedData.map((row, idx) => (
+                      <TableRow key={String(row.id ?? idx)}>
+                        {columns.map((col) => {
+                          const value = row[col];
+                          return (
+                            <TableCell key={col} className="whitespace-nowrap">
+                              {value === null || value === undefined || value === "" ? "-" : String(value)}
+                            </TableCell>
+                          );
+                        })}
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </div>
+            {!loading && (
+              <Pagination
+                config={tableConfig.paginationConfig}
+                onPageChange={tableConfig.setCurrentPage}
+                onPageSizeChange={tableConfig.setPageSize}
+                onFirstPage={tableConfig.goToFirstPage}
+                onLastPage={tableConfig.goToLastPage}
+                onNextPage={tableConfig.goToNextPage}
+                onPreviousPage={tableConfig.goToPreviousPage}
+                canGoNext={tableConfig.canGoNext}
+                canGoPrevious={tableConfig.canGoPrevious}
+                pageSizeOptions={[5, 10, 20]}
+              />
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Consumer Points Map</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="h-[500px]">
+              <LeafletMap
+                devices={mapDevices}
+                pipelines={[]}
+                valves={[]}
+                consumers={mapConsumers}
+                showDevices={mapDevices.length > 0}
+                showPipelines={false}
+                showValves={false}
+                showConsumers={mapConsumers.length > 0}
+              />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};

--- a/src/components/LeafletMap.tsx
+++ b/src/components/LeafletMap.tsx
@@ -135,13 +135,24 @@ interface CatastrophePoint {
   description?: string;
 }
 
+interface ConsumerPoint {
+  id: string;
+  name?: string;
+  code?: string;
+  mobile?: string;
+  status?: string;
+  coordinates: { lat: number; lng: number };
+}
+
 interface LeafletMapProps {
   devices: DeviceLocation[];
   pipelines: PipelineSegment[];
   valves: ValvePoint[];
+  consumers?: ConsumerPoint[];
   showDevices: boolean;
   showPipelines: boolean;
   showValves: boolean;
+  showConsumers?: boolean;
   onMapClick?: (lat: number, lng: number) => void;
   selectedLocation?: { lat: number; lng: number } | null;
   disableAutoFit?: boolean;
@@ -167,9 +178,11 @@ export const LeafletMap = ({
   devices,
   pipelines,
   valves,
+  consumers = [],
   showDevices,
   showPipelines,
   showValves,
+  showConsumers = false,
   onMapClick,
   selectedLocation,
   disableAutoFit,
@@ -181,6 +194,7 @@ export const LeafletMap = ({
   const [markersLayer, setMarkersLayer] = useState<L.LayerGroup | null>(null);
   const [pipelinesLayer, setPipelinesLayer] = useState<L.LayerGroup | null>(null);
   const [valvesLayer, setValvesLayer] = useState<L.LayerGroup | null>(null);
+  const [consumersLayer, setConsumersLayer] = useState<L.LayerGroup | null>(null);
   const [catastrophesLayer, setCatastrophesLayer] = useState<L.LayerGroup | null>(null);
   const [selectionLayer, setSelectionLayer] = useState<L.LayerGroup | null>(null);
   const lastBoundsRef = useRef<LatLngBounds | null>(null);
@@ -253,12 +267,14 @@ export const LeafletMap = ({
     const deviceLayer = L.layerGroup().addTo(map);
     const pipelineLayer = L.layerGroup().addTo(map);
     const valveLayer = L.layerGroup().addTo(map);
+    const consumerLayer = L.layerGroup().addTo(map);
     const catastropheLayer = L.layerGroup().addTo(map);
     const selectionLayerGroup = L.layerGroup().addTo(map);
 
     setMarkersLayer(deviceLayer);
     setPipelinesLayer(pipelineLayer);
     setValvesLayer(valveLayer);
+    setConsumersLayer(consumerLayer);
     setCatastrophesLayer(catastropheLayer);
     setSelectionLayer(selectionLayerGroup);
 
@@ -460,6 +476,36 @@ export const LeafletMap = ({
   }, [selectedLocation, selectionLayer]);
 
   useEffect(() => {
+    if (!consumersLayer) return;
+    consumersLayer.clearLayers();
+
+    if (showConsumers && consumers) {
+      consumers.forEach((consumer) => {
+        if (!isFiniteCoordinate(consumer.coordinates.lat, consumer.coordinates.lng)) return;
+
+        const marker = L.circleMarker([consumer.coordinates.lat, consumer.coordinates.lng], {
+          radius: 7,
+          fillColor: "#fb923c", // orange-400
+          color: "white",
+          weight: 2,
+          opacity: 1,
+          fillOpacity: 0.9,
+        });
+
+        marker.bindPopup(`
+          <div style="font-family: system-ui; padding: 4px; min-width: 180px;">
+            <strong>${consumer.name || "Consumer"}</strong><br/>
+            <span style="color: #666;">Code: ${consumer.code || "N/A"}</span><br/>
+            <span style="color: #666;">Mobile: ${consumer.mobile || "N/A"}</span><br/>
+            <span style="color: #666;">Status: ${consumer.status || "N/A"}</span>
+          </div>
+        `);
+        consumersLayer.addLayer(marker);
+      });
+    }
+  }, [consumers, showConsumers, consumersLayer]);
+
+  useEffect(() => {
     const map = mapInstanceRef.current;
     if (!map) return;
 
@@ -483,6 +529,14 @@ export const LeafletMap = ({
       valvePositions.forEach((coord) => {
         if (coord) {
           points.push(coord);
+        }
+      });
+    }
+
+    if (showConsumers && consumers) {
+      consumers.forEach((c) => {
+        if (isFiniteCoordinate(c.coordinates.lat, c.coordinates.lng)) {
+          points.push([c.coordinates.lat, c.coordinates.lng]);
         }
       });
     }
@@ -527,12 +581,12 @@ export const LeafletMap = ({
     map.fitBounds(bounds, { padding: [32, 32], maxZoom: 17 });
     lastBoundsRef.current = bounds;
     lastCenterRef.current = null;
-  }, [devicePositions, pipelineRoutes, valvePositions, catastrophePositions, showDevices, showPipelines, showValves, showCatastrophes, disableAutoFit, selectedLocation]);
+  }, [devicePositions, pipelineRoutes, valvePositions, catastrophePositions, showDevices, showPipelines, showValves, showConsumers, showCatastrophes, disableAutoFit, selectedLocation]);
 
   return (
     <div className="w-full h-full relative">
       <div ref={mapRef} className="w-full h-full rounded-lg leaflet-container" />
-      {(showPipelines || showValves || showCatastrophes) && (
+      {(showPipelines || showValves || showConsumers || showCatastrophes) && (
         <div className="absolute top-2 left-2 z-[10002] bg-background/90 backdrop-blur-sm border border-border rounded-md px-3 py-2 text-xs text-muted-foreground">
           <div className="flex items-center space-x-1">
             <div className="w-2 h-2 bg-muted-foreground rounded-full"></div>

--- a/src/components/LeafletMap.tsx
+++ b/src/components/LeafletMap.tsx
@@ -233,7 +233,14 @@ export const LeafletMap = ({
       return fallback ? [...fallback] : null;
     });
   }, [valves]);
-
+  const consumerPositions = useMemo<( [number, number] | null )[]>(() => {
+    return consumers.map((valve, index) => {
+      const derived = sanitizeCoordinate(valve.coordinates);
+      if (derived) return derived;
+      const fallback = DEFAULT_VALVE_POSITIONS[index];
+      return fallback ? [...fallback] : null;
+    });
+  }, [valves]);
   const catastrophePositions = useMemo<[number, number][]>(() => {
     return (catastrophes || [])
       .map((c) => sanitizeCoordinate(c.coordinates))
@@ -505,6 +512,7 @@ export const LeafletMap = ({
     }
   }, [consumers, showConsumers, consumersLayer]);
 
+  
   useEffect(() => {
     const map = mapInstanceRef.current;
     if (!map) return;

--- a/src/components/LeafletMap.tsx
+++ b/src/components/LeafletMap.tsx
@@ -13,8 +13,8 @@ L.Icon.Default.mergeOptions({
     "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png",
 });
 
-const DEFAULT_CENTER: [number, number] = [26.1445, 91.7362];
-const DEFAULT_ZOOM = 13;
+const DEFAULT_CENTER: [number, number] = [23.8315, 91.2868];
+const DEFAULT_ZOOM = 12;
 
 const DEFAULT_PIPELINE_ROUTES: [number, number][][] = [
   [

--- a/src/components/MapDashboard.tsx
+++ b/src/components/MapDashboard.tsx
@@ -6,15 +6,21 @@ import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { LeafletMap } from "@/components/LeafletMap";
 import {
-  MapPin,
   Layers,
   RefreshCw,
   AlertCircle,
 } from "lucide-react";
 import {
-  useAssetPropertiesByType,
-  useConsumerPoints,
+  usePipelineGeoJSON,
+  useValveGeoJSON,
+  useConsumerGeoJSON,
 } from "@/hooks/useApiQueries";
+import {
+  parseGeoJSON,
+  transformPipelineFeatures,
+  transformValveFeatures,
+  transformConsumerFeatures,
+} from "@/lib/geoJsonParser";
 import { useSurveyContext } from "@/contexts/SurveyContext";
 
 // Legacy interfaces for backward compatibility with LeafletMap
@@ -61,6 +67,8 @@ interface ConsumerPoint {
   status?: "active" | "inactive";
   estimatedConsumption?: number;
   consumptionUnit?: string;
+  consumerCode?: string;
+  mobile?: string;
 }
 
 export const MapDashboard = () => {
@@ -72,115 +80,69 @@ export const MapDashboard = () => {
   // Get current survey context
   const { currentSurvey } = useSurveyContext();
 
-  // API hooks - fetch from AssetProperties/ByType endpoint
+  // API hooks - fetch GeoJSON from survey-geojson endpoint
   const {
-    data: pipelinesResponse,
+    data: pipelinesGeoJSON,
     isLoading: loadingPipelines,
     error: pipelinesError,
     refetch: refetchPipelines,
-  } = useAssetPropertiesByType("pipeline");
+  } = usePipelineGeoJSON();
 
   const {
-    data: valvesResponse,
+    data: valvesGeoJSON,
     isLoading: loadingValves,
     error: valvesError,
     refetch: refetchValves,
-  } = useAssetPropertiesByType("valve");
+  } = useValveGeoJSON();
 
   const {
-    data: consumerPointsResponse,
+    data: consumerGeoJSON,
     isLoading: loadingConsumerPoints,
     error: consumerPointsError,
     refetch: refetchConsumerPoints,
-  } = useConsumerPoints();
+  } = useConsumerGeoJSON();
 
-  // Transform pipeline data from API
+  // Transform pipeline GeoJSON data
   const transformedPipelines: PipelineSegment[] = useMemo(() => {
-    if (!showPipelines) return [];
+    if (!showPipelines || !pipelinesGeoJSON?.data) return [];
 
-    const pipelines = Array.isArray(pipelinesResponse?.data)
-      ? pipelinesResponse.data
-      : [];
+    const geoJsonString = pipelinesGeoJSON.data;
+    const featureCollection = parseGeoJSON(geoJsonString);
 
-    return pipelines.map((pipeline: any) => ({
-      id: pipeline.id,
-      name: pipeline.name || `Pipeline ${pipeline.id}`,
-      type: pipeline.type || "UNKNOWN",
-      diameter: pipeline.specifications?.diameter?.value || 0,
-      depth: pipeline.installation?.depthBelowGround || 0,
-      status: pipeline.status === "OPERATIONAL"
-        ? "normal"
-        : pipeline.status === "MAINTENANCE"
-        ? "maintenance"
-        : pipeline.status === "DAMAGED"
-        ? "critical"
-        : "warning",
-      material: pipeline.specifications?.material || "UNKNOWN",
-      coordinates: (pipeline.coordinates || []).map((coord: any) => ({
-        lat: typeof coord.lat === "number" ? coord.lat : 0,
-        lng: typeof coord.lng === "number" ? coord.lng : 0,
-        elevation: coord.elevation,
-      })),
-    }));
-  }, [pipelinesResponse?.data, showPipelines]);
+    if (!featureCollection || !featureCollection.features) {
+      return [];
+    }
 
-  // Transform valve data from API
+    return transformPipelineFeatures(featureCollection.features);
+  }, [pipelinesGeoJSON?.data, showPipelines]);
+
+  // Transform valve GeoJSON data
   const transformedValves: ValvePoint[] = useMemo(() => {
-    if (!showValves) return [];
+    if (!showValves || !valvesGeoJSON?.data) return [];
 
-    const valves = Array.isArray(valvesResponse?.data) ? valvesResponse.data : [];
+    const geoJsonString = valvesGeoJSON.data;
+    const featureCollection = parseGeoJSON(geoJsonString);
 
-    return valves.map((valve: any) => ({
-      id: valve.id,
-      name: valve.name || `Valve ${valve.id}`,
-      type: valve.type === "ISOLATION" ? "isolation" : "station",
-      status: valve.status === "OPEN"
-        ? "open"
-        : valve.status === "CLOSED"
-        ? "closed"
-        : valve.status === "MAINTENANCE"
-        ? "maintenance"
-        : "fault",
-      segmentId: valve.pipelineId || "Unknown",
-      coordinates: valve.coordinates
-        ? {
-            lat: typeof valve.coordinates.lat === "number" ? valve.coordinates.lat : 0,
-            lng: typeof valve.coordinates.lng === "number" ? valve.coordinates.lng : 0,
-            elevation: valve.coordinates.elevation,
-          }
-        : undefined,
-      criticality: valve.criticality || "MEDIUM",
-    }));
-  }, [valvesResponse?.data, showValves]);
+    if (!featureCollection || !featureCollection.features) {
+      return [];
+    }
 
-  // Transform consumer points data from API
+    return transformValveFeatures(featureCollection.features);
+  }, [valvesGeoJSON?.data, showValves]);
+
+  // Transform consumer GeoJSON data
   const transformedConsumerPoints: ConsumerPoint[] = useMemo(() => {
-    if (!showConsumerPoints) return [];
+    if (!showConsumerPoints || !consumerGeoJSON?.data) return [];
 
-    const consumers = Array.isArray(consumerPointsResponse?.data)
-      ? consumerPointsResponse.data
-      : [];
+    const geoJsonString = consumerGeoJSON.data;
+    const featureCollection = parseGeoJSON(geoJsonString);
 
-    return consumers
-      .filter((consumer: any) => consumer.coordinates)
-      .map((consumer: any) => ({
-        id: consumer.id,
-        name: consumer.name || `Consumer ${consumer.id}`,
-        lat: typeof consumer.coordinates.lat === "number"
-          ? consumer.coordinates.lat
-          : 0,
-        lng: typeof consumer.coordinates.lng === "number"
-          ? consumer.coordinates.lng
-          : 0,
-        type: consumer.type || "DOMESTIC",
-        category: consumer.consumerCategory?.type || "DOMESTIC",
-        status: consumer.status || "active",
-        estimatedConsumption:
-          consumer.consumerCategory?.estimatedConsumption || 0,
-        consumptionUnit: "m³/day",
-      }))
-      .filter((c) => c.lat !== 0 && c.lng !== 0); // Filter out points with invalid coordinates
-  }, [consumerPointsResponse?.data, showConsumerPoints]);
+    if (!featureCollection || !featureCollection.features) {
+      return [];
+    }
+
+    return transformConsumerFeatures(featureCollection.features);
+  }, [consumerGeoJSON?.data, showConsumerPoints]);
 
   // Use transformed data as display data
   const displayPipelines = transformedPipelines;
@@ -323,7 +285,7 @@ export const MapDashboard = () => {
               </Badge>
             </div>
           </CardHeader>
-          <CardContent className="space-y-3">
+          <CardContent className="space-y-3 max-h-64 overflow-y-auto">
             {displayPipelines.length === 0 ? (
               <p className="text-xs text-muted-foreground">No pipelines available</p>
             ) : (
@@ -337,9 +299,11 @@ export const MapDashboard = () => {
                     <p className="text-xs text-muted-foreground">
                       ⌀{pipeline.diameter}mm • {pipeline.depth}m deep
                     </p>
-                    <p className="text-xs text-muted-foreground">
-                      {pipeline.material}
-                    </p>
+                    {pipeline.material && (
+                      <p className="text-xs text-muted-foreground">
+                        {pipeline.material}
+                      </p>
+                    )}
                   </div>
                   <Badge className={getStatusColor(pipeline.status)}>
                     {pipeline.status.toUpperCase()}
@@ -357,7 +321,7 @@ export const MapDashboard = () => {
               Valves & Isolation Points ({displayValves.length})
             </CardTitle>
           </CardHeader>
-          <CardContent className="space-y-3">
+          <CardContent className="space-y-3 max-h-64 overflow-y-auto">
             {displayValves.length === 0 ? (
               <p className="text-xs text-muted-foreground">No valves available</p>
             ) : (
@@ -384,9 +348,11 @@ export const MapDashboard = () => {
         {/* Consumer Points */}
         <Card>
           <CardHeader className="pb-3">
-            <CardTitle className="text-lg">Consumer Points ({displayConsumerPoints.length})</CardTitle>
+            <CardTitle className="text-lg">
+              Consumer Points ({displayConsumerPoints.length})
+            </CardTitle>
           </CardHeader>
-          <CardContent className="space-y-3">
+          <CardContent className="space-y-3 max-h-64 overflow-y-auto">
             {displayConsumerPoints.length === 0 ? (
               <p className="text-xs text-muted-foreground">No consumer points available</p>
             ) : (
@@ -398,9 +364,18 @@ export const MapDashboard = () => {
                   <div>
                     <p className="font-medium text-sm">{consumer.name}</p>
                     <p className="text-xs text-muted-foreground">
-                      {consumer.category} • {consumer.estimatedConsumption}{" "}
-                      {consumer.consumptionUnit}
+                      {consumer.category}
                     </p>
+                    {consumer.consumerCode && (
+                      <p className="text-xs text-muted-foreground">
+                        Code: {consumer.consumerCode}
+                      </p>
+                    )}
+                    {consumer.mobile && (
+                      <p className="text-xs text-muted-foreground">
+                        {consumer.mobile}
+                      </p>
+                    )}
                   </div>
                   <Badge className={getStatusColor(consumer.status || "active")}>
                     {consumer.status?.toUpperCase() || "ACTIVE"}
@@ -433,10 +408,7 @@ export const MapDashboard = () => {
             </div>
             <div className="flex items-center space-x-2">
               <div className="w-3 h-3 bg-orange-500 rounded-full"></div>
-              <span>
-                Operational Valves:{" "}
-                {displayValves.filter((v) => v.status === "open").length}
-              </span>
+              <span>Valves: {displayValves.length}</span>
             </div>
             <div className="flex items-center space-x-2">
               <div className="w-3 h-3 bg-purple-500 rounded-full"></div>

--- a/src/components/MapDashboard.tsx
+++ b/src/components/MapDashboard.tsx
@@ -8,28 +8,13 @@ import { LeafletMap } from "@/components/LeafletMap";
 import {
   MapPin,
   Layers,
-  Wifi,
-  WifiOff,
-  Activity,
-  Filter,
   RefreshCw,
   AlertCircle,
-  Settings,
-  Shield,
-  Radio,
 } from "lucide-react";
-import { useDeviceLogs, usePipelines, useValves } from "@/hooks/useApiQueries";
 import {
-  mockInfrastructurePipelines,
-  mockInfrastructureValves,
-  mockControlStations,
-  getAssetColorByStatus,
-  getPipelineColorByType,
-  getValveColorByClass,
-  type InfrastructurePipeline,
-  type InfrastructureValve,
-  type ControlStation,
-} from "@/lib/mockAssetData";
+  useAssetPropertiesByType,
+  useConsumerPoints,
+} from "@/hooks/useApiQueries";
 import { useSurveyContext } from "@/contexts/SurveyContext";
 
 // Legacy interfaces for backward compatibility with LeafletMap
@@ -66,110 +51,151 @@ interface ValvePoint {
   criticality?: string;
 }
 
+interface ConsumerPoint {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  type: string;
+  category?: string;
+  status?: "active" | "inactive";
+  estimatedConsumption?: number;
+  consumptionUnit?: string;
+}
+
 export const MapDashboard = () => {
-  // Enhanced layer controls for comprehensive asset types
+  // Simplified layer controls
   const [showPipelines, setShowPipelines] = useState(true);
   const [showValves, setShowValves] = useState(true);
-  const [showDevices, setShowDevices] = useState(true);
-  const [showControlStations, setShowControlStations] = useState(true);
-  const [showUnderground, setShowUnderground] = useState(true);
-  const [showAboveGround, setShowAboveGround] = useState(true);
-  const [showServiceLines, setShowServiceLines] = useState(true);
+  const [showConsumerPoints, setShowConsumerPoints] = useState(true);
 
   // Get current survey context
   const { currentSurvey } = useSurveyContext();
 
-  // API hooks
-  const {
-    data: devicesResponse,
-    isLoading: loadingDevices,
-    error: devicesError,
-    refetch: refetchDevices,
-  } = useDeviceLogs({ limit: 100, surveyId: currentSurvey?.id });
+  // API hooks - fetch from AssetProperties/ByType endpoint
   const {
     data: pipelinesResponse,
     isLoading: loadingPipelines,
     error: pipelinesError,
     refetch: refetchPipelines,
-  } = usePipelines({ limit: 100 });
+  } = useAssetPropertiesByType("pipeline");
+
   const {
     data: valvesResponse,
     isLoading: loadingValves,
     error: valvesError,
     refetch: refetchValves,
-  } = useValves({ limit: 100 });
+  } = useAssetPropertiesByType("valve");
 
-  // Transform device log data to format compatible with existing LeafletMap
-  const transformedDevices: DeviceLocation[] = useMemo(() => {
-    const devices = Array.isArray(devicesResponse?.data) ? devicesResponse.data : [];
-    return devices.map((device) => ({
-      id: device.id,
-      name: device.name,
-      lat: device.coordinates?.lat ?? 0,
-      lng: device.coordinates?.lng ?? 0,
-      status: device.status === "ACTIVE" ? "active" :
-              device.status === "INACTIVE" ? "offline" :
-              device.status === "MAINTENANCE" ? "maintenance" : "error",
-      lastPing: device.lastSeen ? new Date(device.lastSeen).toLocaleString() : "Just now",
-      type: device.type,
-      batteryLevel: device.batteryLevel,
-    }));
-  }, [devicesResponse?.data]);
+  const {
+    data: consumerPointsResponse,
+    isLoading: loadingConsumerPoints,
+    error: consumerPointsError,
+    refetch: refetchConsumerPoints,
+  } = useConsumerPoints();
 
+  // Transform pipeline data from API
   const transformedPipelines: PipelineSegment[] = useMemo(() => {
-    return mockInfrastructurePipelines
-      .filter(pipeline => {
-        if (!showPipelines) return false;
-        if (pipeline.type === "UNDERGROUND" && !showUnderground) return false;
-        if (pipeline.type === "ABOVE_GROUND" && !showAboveGround) return false;
-        if (pipeline.type === "SERVICE" && !showServiceLines) return false;
-        return true;
-      })
-      .map((pipeline) => ({
-        id: pipeline.id,
-        name: pipeline.name,
-        type: pipeline.type,
-        diameter: pipeline.diameter,
-        depth: pipeline.depth || 1.5,
-        status: pipeline.status === "OPERATIONAL" ? "normal" :
-                pipeline.status === "MAINTENANCE" ? "maintenance" :
-                pipeline.status === "DAMAGED" ? "critical" : "warning",
-        material: pipeline.material,
-        coordinates: pipeline.coordinates,
-      }));
-  }, [showPipelines, showUnderground, showAboveGround, showServiceLines]);
+    if (!showPipelines) return [];
 
-  const transformedValves: ValvePoint[] = useMemo(() => {
-    return mockInfrastructureValves.map((valve) => ({
-      id: valve.id,
-      name: valve.name,
-      type: valve.valveClass === "ISOLATION_POINT" ? "isolation" :
-            valve.valveClass === "VALVE_STATION" ? "station" :
-            valve.type === "EMERGENCY_SHUTDOWN" ? "emergency" : "control",
-      status: valve.status === "OPEN" ? "open" :
-              valve.status === "CLOSED" ? "closed" :
-              valve.status === "MAINTENANCE" ? "maintenance" :
-              valve.status === "FAULT" ? "fault" : "closed",
-      segmentId: valve.pipelineId || "Unknown",
-      coordinates: valve.coordinates,
-      criticality: valve.criticality,
+    const pipelines = Array.isArray(pipelinesResponse?.data)
+      ? pipelinesResponse.data
+      : [];
+
+    return pipelines.map((pipeline: any) => ({
+      id: pipeline.id,
+      name: pipeline.name || `Pipeline ${pipeline.id}`,
+      type: pipeline.type || "UNKNOWN",
+      diameter: pipeline.specifications?.diameter?.value || 0,
+      depth: pipeline.installation?.depthBelowGround || 0,
+      status: pipeline.status === "OPERATIONAL"
+        ? "normal"
+        : pipeline.status === "MAINTENANCE"
+        ? "maintenance"
+        : pipeline.status === "DAMAGED"
+        ? "critical"
+        : "warning",
+      material: pipeline.specifications?.material || "UNKNOWN",
+      coordinates: (pipeline.coordinates || []).map((coord: any) => ({
+        lat: typeof coord.lat === "number" ? coord.lat : 0,
+        lng: typeof coord.lng === "number" ? coord.lng : 0,
+        elevation: coord.elevation,
+      })),
     }));
-  }, []);
+  }, [pipelinesResponse?.data, showPipelines]);
 
-  // Use transformed infrastructure data as primary display data
-  const displayDevices = transformedDevices;
+  // Transform valve data from API
+  const transformedValves: ValvePoint[] = useMemo(() => {
+    if (!showValves) return [];
+
+    const valves = Array.isArray(valvesResponse?.data) ? valvesResponse.data : [];
+
+    return valves.map((valve: any) => ({
+      id: valve.id,
+      name: valve.name || `Valve ${valve.id}`,
+      type: valve.type === "ISOLATION" ? "isolation" : "station",
+      status: valve.status === "OPEN"
+        ? "open"
+        : valve.status === "CLOSED"
+        ? "closed"
+        : valve.status === "MAINTENANCE"
+        ? "maintenance"
+        : "fault",
+      segmentId: valve.pipelineId || "Unknown",
+      coordinates: valve.coordinates
+        ? {
+            lat: typeof valve.coordinates.lat === "number" ? valve.coordinates.lat : 0,
+            lng: typeof valve.coordinates.lng === "number" ? valve.coordinates.lng : 0,
+            elevation: valve.coordinates.elevation,
+          }
+        : undefined,
+      criticality: valve.criticality || "MEDIUM",
+    }));
+  }, [valvesResponse?.data, showValves]);
+
+  // Transform consumer points data from API
+  const transformedConsumerPoints: ConsumerPoint[] = useMemo(() => {
+    if (!showConsumerPoints) return [];
+
+    const consumers = Array.isArray(consumerPointsResponse?.data)
+      ? consumerPointsResponse.data
+      : [];
+
+    return consumers
+      .filter((consumer: any) => consumer.coordinates)
+      .map((consumer: any) => ({
+        id: consumer.id,
+        name: consumer.name || `Consumer ${consumer.id}`,
+        lat: typeof consumer.coordinates.lat === "number"
+          ? consumer.coordinates.lat
+          : 0,
+        lng: typeof consumer.coordinates.lng === "number"
+          ? consumer.coordinates.lng
+          : 0,
+        type: consumer.type || "DOMESTIC",
+        category: consumer.consumerCategory?.type || "DOMESTIC",
+        status: consumer.status || "active",
+        estimatedConsumption:
+          consumer.consumerCategory?.estimatedConsumption || 0,
+        consumptionUnit: "m³/day",
+      }))
+      .filter((c) => c.lat !== 0 && c.lng !== 0); // Filter out points with invalid coordinates
+  }, [consumerPointsResponse?.data, showConsumerPoints]);
+
+  // Use transformed data as display data
   const displayPipelines = transformedPipelines;
   const displayValves = transformedValves;
-  const displayControlStations = mockControlStations;
+  const displayConsumerPoints = transformedConsumerPoints;
 
   const handleRefresh = () => {
-    refetchDevices();
     refetchPipelines();
     refetchValves();
+    refetchConsumerPoints();
   };
 
-  const isLoading = loadingDevices || loadingPipelines || loadingValves;
-  const hasError = devicesError || pipelinesError || valvesError;
+  const isLoading =
+    loadingPipelines || loadingValves || loadingConsumerPoints;
+  const hasError = pipelinesError || valvesError || consumerPointsError;
 
   const getStatusColor = (status: string) => {
     switch (status) {
@@ -202,7 +228,7 @@ export const MapDashboard = () => {
 
   return (
     <div className="flex h-screen bg-background">
-      {/* Enhanced Layer Controls Panel */}
+      {/* Layer Controls Panel */}
       <div className="w-80 border-r border-border bg-card p-4 space-y-4 overflow-y-auto max-h-screen">
         {/* Error State */}
         {hasError && (
@@ -213,7 +239,7 @@ export const MapDashboard = () => {
                 <div>
                   <p className="text-sm font-medium">API Connection Issue</p>
                   <p className="text-xs text-muted-foreground">
-                    Using comprehensive mock infrastructure data
+                    Data may be incomplete or unavailable
                   </p>
                 </div>
               </div>
@@ -231,57 +257,16 @@ export const MapDashboard = () => {
           </CardHeader>
           <CardContent className="space-y-4">
             {/* Pipeline Controls */}
-            <div className="space-y-3">
-              <div className="flex items-center justify-between">
-                <Label htmlFor="pipelines" className="flex items-center space-x-2">
-                  <div className="w-3 h-3 bg-blue-500 rounded-full"></div>
-                  <span>Pipeline Network</span>
-                </Label>
-                <Switch
-                  id="pipelines"
-                  checked={showPipelines}
-                  onCheckedChange={setShowPipelines}
-                />
-              </div>
-              
-              {/* Pipeline Type Filters */}
-              {showPipelines && (
-                <div className="ml-5 space-y-2 text-sm">
-                  <div className="flex items-center justify-between">
-                    <Label htmlFor="underground" className="flex items-center space-x-2">
-                      <div className="w-2 h-2 bg-blue-700 rounded-full"></div>
-                      <span>Underground Pipelines</span>
-                    </Label>
-                    <Switch
-                      id="underground"
-                      checked={showUnderground}
-                      onCheckedChange={setShowUnderground}
-                    />
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <Label htmlFor="aboveground" className="flex items-center space-x-2">
-                      <div className="w-2 h-2 bg-purple-500 rounded-full"></div>
-                      <span>Above-Ground Pipelines</span>
-                    </Label>
-                    <Switch
-                      id="aboveground"
-                      checked={showAboveGround}
-                      onCheckedChange={setShowAboveGround}
-                    />
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <Label htmlFor="service" className="flex items-center space-x-2">
-                      <div className="w-2 h-2 bg-green-600 rounded-full"></div>
-                      <span>Service Pipelines</span>
-                    </Label>
-                    <Switch
-                      id="service"
-                      checked={showServiceLines}
-                      onCheckedChange={setShowServiceLines}
-                    />
-                  </div>
-                </div>
-              )}
+            <div className="flex items-center justify-between">
+              <Label htmlFor="pipelines" className="flex items-center space-x-2">
+                <div className="w-3 h-3 bg-blue-500 rounded-full"></div>
+                <span>Pipeline Network</span>
+              </Label>
+              <Switch
+                id="pipelines"
+                checked={showPipelines}
+                onCheckedChange={setShowPipelines}
+              />
             </div>
 
             {/* Valve Controls */}
@@ -297,29 +282,19 @@ export const MapDashboard = () => {
               />
             </div>
 
-            {/* Device Controls */}
+            {/* Consumer Points Controls */}
             <div className="flex items-center justify-between">
-              <Label htmlFor="devices" className="flex items-center space-x-2">
-                <div className="w-3 h-3 bg-green-500 rounded-full"></div>
-                <span>Monitoring Devices</span>
+              <Label
+                htmlFor="consumer-points"
+                className="flex items-center space-x-2"
+              >
+                <div className="w-3 h-3 bg-purple-500 rounded-full"></div>
+                <span>Consumer Points</span>
               </Label>
               <Switch
-                id="devices"
-                checked={showDevices}
-                onCheckedChange={setShowDevices}
-              />
-            </div>
-
-            {/* Control Stations */}
-            <div className="flex items-center justify-between">
-              <Label htmlFor="control-stations" className="flex items-center space-x-2">
-                <div className="w-3 h-3 bg-indigo-500 rounded-full"></div>
-                <span>Control Stations</span>
-              </Label>
-              <Switch
-                id="control-stations"
-                checked={showControlStations}
-                onCheckedChange={setShowControlStations}
+                id="consumer-points"
+                checked={showConsumerPoints}
+                onCheckedChange={setShowConsumerPoints}
               />
             </div>
 
@@ -336,51 +311,6 @@ export const MapDashboard = () => {
           </CardContent>
         </Card>
 
-        {/* Monitoring Devices Status */}
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-lg flex items-center">
-              <Activity className="w-5 h-5 mr-2" />
-              Monitoring Devices ({displayDevices.length})
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {displayDevices.map((device) => (
-              <div
-                key={device.id}
-                className="flex items-center justify-between p-3 border border-border rounded-lg"
-              >
-                <div className="flex items-center space-x-3">
-                  {device.status === "active" ? (
-                    <Wifi className="w-4 h-4 text-success" />
-                  ) : device.status === "maintenance" ? (
-                    <Settings className="w-4 h-4 text-warning" />
-                  ) : (
-                    <WifiOff className="w-4 h-4 text-destructive" />
-                  )}
-                  <div>
-                    <p className="font-medium text-sm">{device.name}</p>
-                    <p className="text-xs text-muted-foreground">{device.type}</p>
-                    {device.batteryLevel && (
-                      <p className="text-xs text-muted-foreground">
-                        Battery: {device.batteryLevel}%
-                      </p>
-                    )}
-                  </div>
-                </div>
-                <div className="text-right">
-                  <Badge className={getStatusColor(device.status)}>
-                    {device.status.toUpperCase()}
-                  </Badge>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    {device.lastPing}
-                  </p>
-                </div>
-              </div>
-            ))}
-          </CardContent>
-        </Card>
-
         {/* Pipeline Network Status */}
         <Card>
           <CardHeader className="pb-3">
@@ -394,25 +324,29 @@ export const MapDashboard = () => {
             </div>
           </CardHeader>
           <CardContent className="space-y-3">
-            {displayPipelines.map((pipeline) => (
-              <div
-                key={pipeline.id}
-                className="flex items-center justify-between p-3 border border-border rounded-lg"
-              >
-                <div>
-                  <p className="font-medium text-sm">{pipeline.name}</p>
-                  <p className="text-xs text-muted-foreground">
-                    {pipeline.type} • ⌀{pipeline.diameter}mm • {pipeline.depth}m deep
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    {pipeline.material}
-                  </p>
+            {displayPipelines.length === 0 ? (
+              <p className="text-xs text-muted-foreground">No pipelines available</p>
+            ) : (
+              displayPipelines.map((pipeline) => (
+                <div
+                  key={pipeline.id}
+                  className="flex items-center justify-between p-3 border border-border rounded-lg"
+                >
+                  <div>
+                    <p className="font-medium text-sm">{pipeline.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      ⌀{pipeline.diameter}mm • {pipeline.depth}m deep
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {pipeline.material}
+                    </p>
+                  </div>
+                  <Badge className={getStatusColor(pipeline.status)}>
+                    {pipeline.status.toUpperCase()}
+                  </Badge>
                 </div>
-                <Badge className={getStatusColor(pipeline.status)}>
-                  {pipeline.status.toUpperCase()}
-                </Badge>
-              </div>
-            ))}
+              ))
+            )}
           </CardContent>
         </Card>
 
@@ -424,50 +358,56 @@ export const MapDashboard = () => {
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
-            {displayValves.map((valve) => (
-              <div
-                key={valve.id}
-                className="flex items-center justify-between p-3 border border-border rounded-lg"
-              >
-                <div>
-                  <p className="font-medium text-sm">{valve.name}</p>
-                  <p className="text-xs text-muted-foreground capitalize">
-                    {valve.type} • {valve.criticality} criticality
-                  </p>
+            {displayValves.length === 0 ? (
+              <p className="text-xs text-muted-foreground">No valves available</p>
+            ) : (
+              displayValves.map((valve) => (
+                <div
+                  key={valve.id}
+                  className="flex items-center justify-between p-3 border border-border rounded-lg"
+                >
+                  <div>
+                    <p className="font-medium text-sm">{valve.name}</p>
+                    <p className="text-xs text-muted-foreground capitalize">
+                      {valve.type} • {valve.criticality} criticality
+                    </p>
+                  </div>
+                  <Badge className={getStatusColor(valve.status)}>
+                    {valve.status.toUpperCase()}
+                  </Badge>
                 </div>
-                <Badge className={getStatusColor(valve.status)}>
-                  {valve.status.toUpperCase()}
-                </Badge>
-              </div>
-            ))}
+              ))
+            )}
           </CardContent>
         </Card>
 
-        {/* Control Stations */}
+        {/* Consumer Points */}
         <Card>
           <CardHeader className="pb-3">
-            <CardTitle className="text-lg flex items-center">
-              <Shield className="w-5 h-5 mr-2" />
-              Control Stations ({displayControlStations.length})
-            </CardTitle>
+            <CardTitle className="text-lg">Consumer Points ({displayConsumerPoints.length})</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
-            {displayControlStations.map((station) => (
-              <div
-                key={station.id}
-                className="flex items-center justify-between p-3 border border-border rounded-lg"
-              >
-                <div>
-                  <p className="font-medium text-sm">{station.name}</p>
-                  <p className="text-xs text-muted-foreground">
-                    {station.type} • {station.controlledPipelines.length} pipelines
-                  </p>
+            {displayConsumerPoints.length === 0 ? (
+              <p className="text-xs text-muted-foreground">No consumer points available</p>
+            ) : (
+              displayConsumerPoints.map((consumer) => (
+                <div
+                  key={consumer.id}
+                  className="flex items-center justify-between p-3 border border-border rounded-lg"
+                >
+                  <div>
+                    <p className="font-medium text-sm">{consumer.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {consumer.category} • {consumer.estimatedConsumption}{" "}
+                      {consumer.consumptionUnit}
+                    </p>
+                  </div>
+                  <Badge className={getStatusColor(consumer.status || "active")}>
+                    {consumer.status?.toUpperCase() || "ACTIVE"}
+                  </Badge>
                 </div>
-                <Badge className={getStatusColor(station.status)}>
-                  {station.status}
-                </Badge>
-              </div>
-            ))}
+              ))
+            )}
           </CardContent>
         </Card>
       </div>
@@ -475,10 +415,10 @@ export const MapDashboard = () => {
       {/* Map Area */}
       <div className="flex-1 relative">
         <LeafletMap
-          devices={displayDevices}
+          devices={displayConsumerPoints as unknown as DeviceLocation[]}
           pipelines={displayPipelines}
           valves={displayValves}
-          showDevices={showDevices}
+          showDevices={showConsumerPoints}
           showPipelines={showPipelines}
           showValves={showValves}
         />
@@ -488,34 +428,19 @@ export const MapDashboard = () => {
           <div className="space-y-2 text-sm">
             <div className="font-medium text-base mb-2">Infrastructure Status</div>
             <div className="flex items-center space-x-2">
-              <div className="w-3 h-3 bg-success rounded-full"></div>
-              <span>
-                Active Devices: {displayDevices.filter((d) => d.status === "active").length}
-              </span>
-            </div>
-            <div className="flex items-center space-x-2">
-              <div className="w-3 h-3 bg-warning rounded-full"></div>
-              <span>
-                Maintenance: {displayDevices.filter((d) => d.status === "maintenance").length}
-              </span>
-            </div>
-            <div className="flex items-center space-x-2">
               <div className="w-3 h-3 bg-blue-500 rounded-full"></div>
-              <span>
-                Underground Lines: {displayPipelines.filter((p) => p.type === "UNDERGROUND").length}
-              </span>
-            </div>
-            <div className="flex items-center space-x-2">
-              <div className="w-3 h-3 bg-purple-500 rounded-full"></div>
-              <span>
-                Above-Ground Lines: {displayPipelines.filter((p) => p.type === "ABOVE_GROUND").length}
-              </span>
+              <span>Pipelines: {displayPipelines.length}</span>
             </div>
             <div className="flex items-center space-x-2">
               <div className="w-3 h-3 bg-orange-500 rounded-full"></div>
               <span>
-                Critical Valves: {displayValves.filter((v) => v.criticality === "CRITICAL").length}
+                Operational Valves:{" "}
+                {displayValves.filter((v) => v.status === "open").length}
               </span>
+            </div>
+            <div className="flex items-center space-x-2">
+              <div className="w-3 h-3 bg-purple-500 rounded-full"></div>
+              <span>Consumer Points: {displayConsumerPoints.length}</span>
             </div>
           </div>
         </div>
@@ -526,24 +451,16 @@ export const MapDashboard = () => {
             <div className="font-medium mb-2">Asset Symbology</div>
             <div className="space-y-1">
               <div className="flex items-center space-x-2">
-                <div className="w-4 h-1 bg-blue-700"></div>
-                <span>Underground Pipeline</span>
-              </div>
-              <div className="flex items-center space-x-2">
-                <div className="w-4 h-1 bg-purple-500"></div>
-                <span>Above-Ground Pipeline</span>
-              </div>
-              <div className="flex items-center space-x-2">
-                <div className="w-4 h-1 bg-green-600 border-dashed border-2 border-green-600"></div>
-                <span>Service Pipeline</span>
+                <div className="w-4 h-1 bg-blue-500"></div>
+                <span>Pipeline</span>
               </div>
               <div className="flex items-center space-x-2">
                 <div className="w-3 h-3 bg-orange-500 rounded-sm"></div>
                 <span>Valve/Isolation Point</span>
               </div>
               <div className="flex items-center space-x-2">
-                <div className="w-3 h-3 bg-green-500 rounded-full"></div>
-                <span>Monitoring Device</span>
+                <div className="w-3 h-3 bg-purple-500 rounded-full"></div>
+                <span>Consumer Point</span>
               </div>
             </div>
           </div>

--- a/src/components/PipelineNetworkEditor.tsx
+++ b/src/components/PipelineNetworkEditor.tsx
@@ -82,7 +82,8 @@ export const PipelineNetworkEditor = () => {
       setPropLoading(true);
       setPropError(null);
       try {
-        const url = `https://localhost:7215/api/SurveyEntries/survey-geojson?atName=PipeLine`;
+        const url = `${API_BASE_PATH}/SurveyEntries/survey-geojson?atName=PipeLine`;
+        //const url = `https://localhost:7215/api/SurveyEntries/survey-geojson?atName=PipeLine`;
         const res = await fetch(url, { signal: controller.signal });
         if (!res.ok) throw new Error(`Request failed: ${res.status}`);
         const json = await res.json();
@@ -148,7 +149,7 @@ export const PipelineNetworkEditor = () => {
     async function loadValves() {
       setValveError(null);
       try {
-        const url = `${API_BASE_PATH}/AssetProperties/ByType/valve`;
+        const url = `${API_BASE_PATH}/api/AssetProperties/ByType/valve`;
         //const url = `https://localhost:7215/api/AssetProperties/ByType/valve`;
         const res = await fetch(url, { signal: controller.signal });
         if (!res.ok) throw new Error(`Request failed: ${res.status}`);
@@ -441,10 +442,10 @@ export const PipelineNetworkEditor = () => {
           <CardContent>
             <div className="h-96">
               <LeafletMap
-                devices={mapDevices}
+                devices={[]}
                 pipelines={mapPipelines}
                 valves={mapValves}
-                showDevices={showDevicesOnMap}
+                showDevices={false}
                 showPipelines={showPipelinesOnMap}
                 showValves={showValvesOnMap}
               />

--- a/src/components/PipelineNetworkEditor.tsx
+++ b/src/components/PipelineNetworkEditor.tsx
@@ -432,7 +432,26 @@ export const PipelineNetworkEditor = () => {
       </div>
 
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="space-y-6">
+        {/* Map View */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Pipeline Network Map</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="h-96">
+              <LeafletMap
+                devices={mapDevices}
+                pipelines={mapPipelines}
+                valves={mapValves}
+                showDevices={showDevicesOnMap}
+                showPipelines={showPipelinesOnMap}
+                showValves={showValvesOnMap}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
         {/* Pipeline Segments List */}
         <Card>
           <CardHeader>
@@ -510,25 +529,6 @@ export const PipelineNetworkEditor = () => {
                 pageSizeOptions={[5, 10, 20]}
               />
             )}
-          </CardContent>
-        </Card>
-
-        {/* Map View */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Pipeline Network Map</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="h-96">
-              <LeafletMap
-                devices={mapDevices}
-                pipelines={mapPipelines}
-                valves={mapValves}
-                showDevices={showDevicesOnMap}
-                showPipelines={showPipelinesOnMap}
-                showValves={showValvesOnMap}
-              />
-            </div>
           </CardContent>
         </Card>
       </div>

--- a/src/components/PipelineNetworkEditor.tsx
+++ b/src/components/PipelineNetworkEditor.tsx
@@ -82,19 +82,53 @@ export const PipelineNetworkEditor = () => {
       setPropLoading(true);
       setPropError(null);
       try {
-        const url = `${API_BASE_PATH}/AssetProperties/ByType/pipeline`;
-        //const url = `https://localhost:7215/api/AssetProperties/ByType/pipeline`;
+        const url = `https://localhost:7215/api/SurveyEntries/survey-geojson?atName=PipeLine`;
         const res = await fetch(url, { signal: controller.signal });
         if (!res.ok) throw new Error(`Request failed: ${res.status}`);
         const json = await res.json();
-        const arr: DynamicRow[] = Array.isArray(json?.data)
-          ? json.data
-          : Array.isArray(json)
-            ? json
-            : [];
-        const normalized = arr.map((item) => ({ ...item }));
+
+        // Parse the GeoJSON from the data field
+        let geojson: any = null;
+        if (json?.data) {
+          try {
+            geojson = typeof json.data === 'string' ? JSON.parse(json.data) : json.data;
+          } catch (parseError) {
+            throw new Error("Failed to parse GeoJSON data");
+          }
+        }
+
+        // Extract features from GeoJSON
+        const features = geojson?.features || [];
+        const normalized = features.map((feature: any, idx: number) => {
+          const props = feature.properties || {};
+          const coords = feature.geometry?.coordinates || [];
+
+          // Convert MultiLineString coordinates to array of coordinate objects
+          let coordinateObjects: Array<{ lat: number; lng: number }> = [];
+          if (coords.length > 0 && Array.isArray(coords[0])) {
+            // For MultiLineString, take the first line
+            const lineCoords = coords[0];
+            coordinateObjects = lineCoords.map((coord: any) => ({
+              lat: coord[1], // latitude is second
+              lng: coord[0], // longitude is first
+            }));
+          }
+
+          return {
+            SE_ID: props.SE_ID || idx,
+            SE_VALUE: props.SE_VALUE || "",
+            depth: props.depth || "",
+            depth_meter: props["depth meter"] || "",
+            SE_ENTRY_DATE: props.SE_ENTRY_DATE || "",
+            pipe_diameter: props["pipe diameter"] || "",
+            SHAPE_LENGTH: props.SHAPE_LENGTH || "",
+            SE_SURVEY_SESSION_ID: props.SE_SURVEY_SESSION_ID || "",
+            coordinates: coordinateObjects,
+          };
+        });
+
         setPropRows(normalized);
-        const cols = normalized.length > 0 ? Object.keys(normalized[0]) : [];
+        const cols = normalized.length > 0 ? Object.keys(normalized[0]).filter(c => c !== 'coordinates') : [];
         setPropColumns(cols);
       } catch (e: any) {
         setPropError(e?.message || "Failed to load data");
@@ -179,17 +213,20 @@ export const PipelineNetworkEditor = () => {
     }));
   }, [deviceLogsResponse]);
 
-  // Pipelines for map from AssetProperties/ByType/pipeline
+  // Pipelines for map from survey-geojson endpoint
   const mapPipelines = useMemo(() => {
-    return propRows.map((r, idx) => {
-      const id = String(r["id"] ?? r["ID"] ?? r["segmentId"] ?? r["SegmentId"] ?? `PS-${idx + 1}`);
-      const diameterVal = Number(r["diameter"] ?? r["Diameter"] ?? r["pipeDiameter"] ?? r["PipeDiameter"] ?? 200);
-      const depthVal = Number(r["depth"] ?? r["Depth"] ?? r["installationDepth"] ?? r["InstallationDepth"] ?? 1.5);
+    return propRows.map((r: any, idx) => {
+      const id = String(r["SE_ID"] ?? r["id"] ?? r["ID"] ?? `PS-${idx + 1}`);
+      const diameterVal = Number(r["pipe_diameter"] ?? r["diameter"] ?? r["Diameter"] ?? r["pipeDiameter"] ?? r["PipeDiameter"] ?? 200);
+      const depthVal = Number(r["depth_meter"] ?? r["depth"] ?? r["Depth"] ?? r["installationDepth"] ?? r["InstallationDepth"] ?? 1.5);
+      const coordinates = Array.isArray(r.coordinates) && r.coordinates.length >= 2 ? r.coordinates : undefined;
       return {
         id,
+        name: `Pipeline ${id}`,
         diameter: Number.isFinite(diameterVal) ? diameterVal : 200,
         depth: Number.isFinite(depthVal) ? depthVal : 1.5,
         status: "normal" as const,
+        coordinates,
       };
     });
   }, [propRows]);
@@ -402,17 +439,22 @@ export const PipelineNetworkEditor = () => {
             <div className="flex items-center justify-between">
               <CardTitle className="flex items-center gap-2">
                 <MapPin className="h-5 w-5" />
-                Valve Points ({propRows.length})
+                Pipeline Segments ({propRows.length})
               </CardTitle>
             </div>
           </CardHeader>
           <CardContent className="p-0">
             <div className="p-6 pb-0">
-              
+              {propError && (
+                <Alert variant="destructive" className="mb-4">
+                  <AlertTriangle className="h-4 w-4" />
+                  <AlertDescription>{propError}</AlertDescription>
+                </Alert>
+              )}
               {propLoading ? (
                 <div className="flex items-center justify-center py-8">
                   <Loader2 className="h-8 w-8 animate-spin" />
-                  <span className="ml-2">Loading asset properties...</span>
+                  <span className="ml-2">Loading pipeline data...</span>
                 </div>
               ) : (
                 <Table>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -81,6 +81,12 @@ const adminManagerMenuItems: MenuItem[] = [
     roles: ["admin", "manager"],
   },
   {
+    id: "valves-map",
+    label: "Valves Map",
+    icon: Map,
+    roles: ["admin", "manager"],
+  },
+  {
     id: "alerts-notifications",
     label: "Alerts & Notifications",
     icon: AlertTriangle,
@@ -198,6 +204,10 @@ export const Sidebar = ({
     }
     if (tabId === "flowlines-map") {
       navigate("/flowlines-map");
+      return;
+    }
+    if (tabId === "valves-map") {
+      navigate("/valves-map");
       return;
     }
     if (tabId.startsWith("assets:")) {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -75,6 +75,12 @@ const adminManagerMenuItems: MenuItem[] = [
     roles: ["admin", "manager"],
   },
   {
+    id: "flowlines-map",
+    label: "Flowlines Map",
+    icon: Map,
+    roles: ["admin", "manager"],
+  },
+  {
     id: "alerts-notifications",
     label: "Alerts & Notifications",
     icon: AlertTriangle,
@@ -188,6 +194,10 @@ export const Sidebar = ({
     onTabChange(tabId);
     if (tabId === "pipeline-operations") {
       navigate("/pipeline-operations");
+      return;
+    }
+    if (tabId === "flowlines-map") {
+      navigate("/flowlines-map");
       return;
     }
     if (tabId.startsWith("assets:")) {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -225,12 +225,14 @@ export const Sidebar = ({
         const findBy = (pred: (a: any) => boolean) => items.find(pred);
         const pipe = findBy((a) => (a.name || "").toLowerCase() === "pipe" || (a.menuName || "").toLowerCase() === "pipeline");
         const valve = findBy((a) => (a.name || "").toLowerCase() === "valve" || (a.menuName || "").toLowerCase() === "valve");
+        const consumer = findBy((a) => (a.name || "").toLowerCase() === "consumer" || (a.menuName || "").toLowerCase() === "consumer");
         const catastrophe = findBy((a) => (a.name || "").toLowerCase() === "catastrophe" || (a.menuName || "").toLowerCase().includes("catastrophe"));
 
         const dyn: Array<{ id: string; label: string; icon: any; order: number; path: string }> = [];
         if (pipe) dyn.push({ id: "assets:pipeline", label: normalizeHeading(pipe.menuName || pipe.name), icon: Pipe, order: pipe.menuOrder ?? 1, path: "/assets/pipeline" });
         if (valve) dyn.push({ id: "assets:valve", label: normalizeHeading(valve.menuName || valve.name), icon: Gauge, order: valve.menuOrder ?? 2, path: "/assets/valve" });
-        if (catastrophe) dyn.push({ id: "assets:catastrophe", label: normalizeHeading(catastrophe.menuName || catastrophe.name), icon: AlertTriangle, order: catastrophe.menuOrder ?? 3, path: "/assets/catastrophe" });
+        if (consumer) dyn.push({ id: "assets:consumer", label: normalizeHeading(consumer.menuName || consumer.name), icon: Users, order: consumer.menuOrder ?? 3, path: "/assets/consumer" });
+        if (catastrophe) dyn.push({ id: "assets:catastrophe", label: normalizeHeading(catastrophe.menuName || catastrophe.name), icon: AlertTriangle, order: catastrophe.menuOrder ?? 4, path: "/assets/catastrophe" });
 
         if (mounted) {
           setAssetMenus(dyn.sort((a, b) => a.order - b.order));
@@ -244,7 +246,7 @@ export const Sidebar = ({
 
   const filteredAssetMenus = assetMenus.filter((m) => {
     if (userRole === "survey") {
-      return m.id !== "assets:pipeline" && m.id !== "assets:valve" && m.id !== "assets:catastrophe";
+      return m.id !== "assets:pipeline" && m.id !== "assets:valve" && m.id !== "assets:consumer" && m.id !== "assets:catastrophe";
     }
     return true;
   });

--- a/src/components/ValvePointsEditor.tsx
+++ b/src/components/ValvePointsEditor.tsx
@@ -205,7 +205,25 @@ export const ValvePointsEditor = () => {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Valve Network Map</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="h-96">
+              <LeafletMap
+                devices={mapDevices}
+                pipelines={mapPipelines}
+                valves={mapValves}
+                showDevices={showDevices}
+                showPipelines={showPipelines}
+                showValves={showValves}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
@@ -273,24 +291,6 @@ export const ValvePointsEditor = () => {
               canGoPrevious={tableConfig.canGoPrevious}
               pageSizeOptions={[5, 10, 20]}
             />
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Valve Network Map</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="h-96">
-              <LeafletMap
-                devices={mapDevices}
-                pipelines={mapPipelines}
-                valves={mapValves}
-                showDevices={showDevices}
-                showPipelines={showPipelines}
-                showValves={showValves}
-              />
-            </div>
           </CardContent>
         </Card>
       </div>

--- a/src/components/ValvePointsEditor.tsx
+++ b/src/components/ValvePointsEditor.tsx
@@ -23,9 +23,11 @@ type DynamicRow = Record<string, any>;
 // Map view expects these fields only
 interface MapValve {
   id: string;
-  type: "control" | "emergency" | "isolation";
-  status: "open" | "closed" | "maintenance";
+  type: "control" | "emergency" | "isolation" | "station";
+  status: "open" | "closed" | "maintenance" | "fault";
   segmentId: string;
+  coordinates?: { lat: number; lng: number };
+  name?: string;
 }
 
 // Map pipeline segment shape expected by LeafletMap
@@ -49,27 +51,50 @@ export const ValvePointsEditor = () => {
   const [pipelineRows, setPipelineRows] = useState<DynamicRow[]>([]);
   const [pipelineError, setPipelineError] = useState<string | null>(null);
 
-  // Load valves table from required endpoint
+  // Load valves table from survey-geojson endpoint
   useEffect(() => {
     const controller = new AbortController();
     async function loadValves() {
       setLoading(true);
       setError(null);
       try {
-        //const url = `https://localhost:7215/api/AssetProperties/ByType/valve`;
-        const url = `${API_BASE_PATH}/AssetProperties/ByType/valve`;
+        const url = `https://localhost:7215/api/SurveyEntries/survey-geojson?atName=Valve`;
         const res = await fetch(url, { signal: controller.signal });
         if (!res.ok) {
           throw new Error(`Request failed: ${res.status}`);
         }
         const json = await res.json();
-        const arr: DynamicRow[] = Array.isArray(json?.data)
-          ? json.data
-          : Array.isArray(json)
-            ? json
-            : [];
 
-        const normalized = arr.map((item) => ({ ...item }));
+        // Parse the GeoJSON from the data field
+        let geojson: any = null;
+        if (json?.data) {
+          try {
+            geojson = typeof json.data === 'string' ? JSON.parse(json.data) : json.data;
+          } catch (parseError) {
+            throw new Error("Failed to parse GeoJSON data");
+          }
+        }
+
+        // Extract features from GeoJSON
+        const features = geojson?.features || [];
+        const normalized = features.map((feature: any, idx: number) => {
+          const props = feature.properties || {};
+          const coords = feature.geometry?.coordinates || [0, 0];
+          return {
+            SE_ID: props.SE_ID || idx,
+            SE_VALUE: props.SE_VALUE || "",
+            bulb_station: props["bulb station"] || "",
+            SE_ENTRY_DATE: props.SE_ENTRY_DATE || "",
+            isolation: props.isolation || "",
+            service_point: props["service point"] || "",
+            control_station: props["control station"] || "",
+            SE_SURVEY_SESSION_ID: props.SE_SURVEY_SESSION_ID || "",
+            SHAPE_LENGTH: props.SHAPE_LENGTH || "",
+            longitude: coords[0] || 0,
+            latitude: coords[1] || 0,
+          };
+        });
+
         setRows(normalized);
         const cols = normalized.length > 0 ? Object.keys(normalized[0]) : [];
         setColumns(cols);
@@ -117,12 +142,16 @@ export const ValvePointsEditor = () => {
   // Derive valves for map layer from dynamic rows
   const mapValves: MapValve[] = useMemo(() => {
     return rows.map((r) => {
-      const rawType = String(r["Type"] ?? r["type"] ?? "").toLowerCase();
-      const mappedType: MapValve["type"] = rawType === "emergency" ? "emergency" : rawType === "isolation" ? "isolation" : "control";
-      const status: MapValve["status"] = mappedType === "emergency" ? "closed" : rawType === "safety" ? "maintenance" : "open";
-      const segment = String(r["Linked Segment"] ?? r["segmentId"] ?? r["Segment"] ?? "Unknown");
-      const id = String(r["id"] ?? r["ID"] ?? "");
-      return { id, type: mappedType, status, segmentId: segment };
+      const rawType = String(r["SE_VALUE"] ?? r["Type"] ?? r["type"] ?? "").toLowerCase();
+      const mappedType: MapValve["type"] = rawType.includes("emergency") ? "emergency" : rawType.includes("isolation") ? "isolation" : "station";
+      const status: MapValve["status"] = "open"; // Default status for valve stations
+      const segment = String(r["SE_ID"] ?? r["Linked Segment"] ?? r["segmentId"] ?? "Unknown");
+      const id = String(r["SE_ID"] ?? r["id"] ?? r["ID"] ?? "");
+      const latitude = Number(r.latitude) || 0;
+      const longitude = Number(r.longitude) || 0;
+      const coordinates = latitude && longitude ? { lat: latitude, lng: longitude } : undefined;
+      const name = r["bulb_station"] || `Valve ${id}`;
+      return { id, type: mappedType, status, segmentId: segment, coordinates, name };
     });
   }, [rows]);
 

--- a/src/components/ValvePointsEditor.tsx
+++ b/src/components/ValvePointsEditor.tsx
@@ -58,7 +58,8 @@ export const ValvePointsEditor = () => {
       setLoading(true);
       setError(null);
       try {
-        const url = `https://localhost:7215/api/SurveyEntries/survey-geojson?atName=Valve`;
+        const url = `${API_BASE_PATH}/SurveyEntries/survey-geojson?atName=Valve`;
+        //const url = `https://localhost:7215/api/SurveyEntries/survey-geojson?atName=Valve`;
         const res = await fetch(url, { signal: controller.signal });
         if (!res.ok) {
           throw new Error(`Request failed: ${res.status}`);
@@ -213,10 +214,10 @@ export const ValvePointsEditor = () => {
           <CardContent>
             <div className="h-96">
               <LeafletMap
-                devices={mapDevices}
+                devices={[]}
                 pipelines={mapPipelines}
                 valves={mapValves}
-                showDevices={showDevices}
+                showDevices={false}
                 showPipelines={showPipelines}
                 showValves={showValves}
               />

--- a/src/hooks/useApiQueries.ts
+++ b/src/hooks/useApiQueries.ts
@@ -43,6 +43,8 @@ export const QUERY_KEYS = {
   pipelineMaterials: "pipelineMaterials",
   statusOptions: "statusOptions",
   surveyCategories: "surveyCategories",
+  assetPropertiesByType: "assetPropertiesByType",
+  consumerPoints: "consumerPoints",
 } as const;
 
 // Device hooks
@@ -593,6 +595,24 @@ export function usePipelineSegmentsByType(type: string = "pipeline") {
   return useQuery({
     queryKey: ["assetPropertiesByType", type],
     queryFn: () => apiClient.getAssetPropertiesByType(type),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+// Asset Properties by Type hooks
+export function useAssetPropertiesByType(type: string) {
+  return useQuery({
+    queryKey: [QUERY_KEYS.assetPropertiesByType, type],
+    queryFn: () => apiClient.getAssetPropertiesByType(type),
+    staleTime: 5 * 60 * 1000,
+    enabled: !!type,
+  });
+}
+
+export function useConsumerPoints() {
+  return useQuery({
+    queryKey: [QUERY_KEYS.consumerPoints],
+    queryFn: () => apiClient.getAssetPropertiesByType("consumer"),
     staleTime: 5 * 60 * 1000,
   });
 }

--- a/src/hooks/useApiQueries.ts
+++ b/src/hooks/useApiQueries.ts
@@ -609,6 +609,28 @@ export function useAssetPropertiesByType(type: string) {
   });
 }
 
+// Survey GeoJSON hooks
+export function useSurveyGeoJSON(atName: "pipeline" | "Valve" | "consumer") {
+  return useQuery({
+    queryKey: ["surveyGeoJSON", atName],
+    queryFn: () => apiClient.getSurveyGeoJSON(atName),
+    staleTime: 5 * 60 * 1000,
+    enabled: !!atName,
+  });
+}
+
+export function usePipelineGeoJSON() {
+  return useSurveyGeoJSON("pipeline");
+}
+
+export function useValveGeoJSON() {
+  return useSurveyGeoJSON("Valve");
+}
+
+export function useConsumerGeoJSON() {
+  return useSurveyGeoJSON("consumer");
+}
+
 export function useConsumerPoints() {
   return useQuery({
     queryKey: [QUERY_KEYS.consumerPoints],

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3665,6 +3665,14 @@ class ApiClient {
       throw new Error(error?.message ?? "Failed to fetch flowlines");
     }
   }
+
+  async getValves(): Promise<any> {
+    try {
+      return await this.request<any>(`/Map/valves`);
+    } catch (error: any) {
+      throw new Error(error?.message ?? "Failed to fetch valves");
+    }
+  }
 }
 
 // Compatibility helpers for backward compatibility with existing components

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3657,6 +3657,14 @@ class ApiClient {
       };
     }
   }
+
+  async getFlowlines(): Promise<any> {
+    try {
+      return await this.request<any>(`/Map/flowlines`);
+    } catch (error: any) {
+      throw new Error(error?.message ?? "Failed to fetch flowlines");
+    }
+  }
 }
 
 // Compatibility helpers for backward compatibility with existing components

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1521,6 +1521,30 @@ class ApiClient {
     }
   }
 
+  // Survey GeoJSON endpoint (e.g., /SurveyEntries/survey-geojson?atName=pipeline)
+  async getSurveyGeoJSON(atName: "pipeline" | "Valve" | "consumer"): Promise<ApiResponse<string>> {
+    try {
+      const raw: any = await this.request<any>(
+        `/SurveyEntries/survey-geojson?atName=${encodeURIComponent(atName)}`
+      );
+      const geoJsonString = typeof raw?.data === "string" ? raw.data : JSON.stringify(raw?.data || "");
+      return {
+        success: true,
+        data: geoJsonString,
+        message: raw?.message ?? raw?.status_message ?? "",
+        timestamp: raw?.timestamp ?? new Date().toISOString(),
+      };
+    } catch (error) {
+      console.error(`Failed to fetch GeoJSON for ${atName}:`, error);
+      return {
+        success: false,
+        data: "",
+        message: `Failed to fetch ${atName} data`,
+        timestamp: new Date().toISOString(),
+      };
+    }
+  }
+
   // Survey Categories endpoints
   async getSurveyCategories(params?: { page?: number; limit?: number; search?: string; }): Promise<PaginatedResponse<SurveyCategoryType>> {
     const sp = new URLSearchParams();

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1507,6 +1507,18 @@ class ApiClient {
     }
   }
 
+  async getSurveyGeoJson(atName: string): Promise<any> {
+    try {
+      return await this.request<any>(`/SurveyEntries/survey-geojson?atName=${encodeURIComponent(atName)}`);
+    } catch (_) {
+      return {
+        success: false,
+        data: null,
+        message: "Failed to fetch geojson",
+      };
+    }
+  }
+
   // Survey Categories endpoints
   async getSurveyCategories(params?: { page?: number; limit?: number; search?: string; }): Promise<PaginatedResponse<SurveyCategoryType>> {
     const sp = new URLSearchParams();

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3671,7 +3671,7 @@ class ApiClient {
     }
   }
 
-  async getValves(): Promise<any> {
+  async getAllValves(): Promise<any> {
     try {
       return await this.request<any>(`/Map/valves`);
     } catch (error: any) {

--- a/src/lib/geoJsonParser.ts
+++ b/src/lib/geoJsonParser.ts
@@ -1,0 +1,200 @@
+// Utility functions for parsing GeoJSON data from survey entries API
+
+interface GeoJSONFeature {
+  type: "Feature";
+  geometry: {
+    type: "Point" | "MultiLineString" | "LineString" | "Polygon";
+    coordinates: any;
+  };
+  properties: Record<string, any>;
+}
+
+interface GeoJSONFeatureCollection {
+  type: "FeatureCollection";
+  features: GeoJSONFeature[];
+}
+
+/**
+ * Parse GeoJSON string response from API
+ * The API returns data as a JSON string that needs to be parsed
+ */
+export function parseGeoJSON(dataString: string): GeoJSONFeatureCollection | null {
+  try {
+    if (typeof dataString !== "string") {
+      return null;
+    }
+    return JSON.parse(dataString) as GeoJSONFeatureCollection;
+  } catch (error) {
+    console.error("Failed to parse GeoJSON:", error);
+    return null;
+  }
+}
+
+/**
+ * Extract point coordinates from GeoJSON feature
+ * GeoJSON uses [longitude, latitude] order
+ */
+export function getPointCoordinates(
+  feature: GeoJSONFeature,
+): { lat: number; lng: number } | null {
+  if (feature.geometry.type === "Point") {
+    const [lng, lat] = feature.geometry.coordinates;
+    return { lat, lng };
+  }
+  return null;
+}
+
+/**
+ * Extract line coordinates from GeoJSON feature
+ * GeoJSON uses [longitude, latitude] order
+ */
+export function getLineCoordinates(
+  feature: GeoJSONFeature,
+): Array<{ lat: number; lng: number; elevation?: number }> {
+  const coords: Array<{ lat: number; lng: number; elevation?: number }> = [];
+
+  if (feature.geometry.type === "MultiLineString") {
+    const lineStrings = feature.geometry.coordinates as number[][][];
+    lineStrings.forEach((line) => {
+      line.forEach(([lng, lat, elevation]) => {
+        coords.push({
+          lat,
+          lng,
+          elevation: elevation ?? undefined,
+        });
+      });
+    });
+  } else if (feature.geometry.type === "LineString") {
+    const line = feature.geometry.coordinates as number[][];
+    line.forEach(([lng, lat, elevation]) => {
+      coords.push({
+        lat,
+        lng,
+        elevation: elevation ?? undefined,
+      });
+    });
+  }
+
+  return coords;
+}
+
+/**
+ * Transform GeoJSON features to pipeline segments
+ */
+export function transformPipelineFeatures(
+  features: GeoJSONFeature[],
+): Array<{
+  id: string;
+  name: string;
+  type: string;
+  diameter: number;
+  depth: number;
+  status: "normal" | "warning" | "critical" | "maintenance";
+  material?: string;
+  coordinates: Array<{ lat: number; lng: number; elevation?: number }>;
+}> {
+  return features
+    .filter((feature) =>
+      ["MultiLineString", "LineString"].includes(feature.geometry.type),
+    )
+    .map((feature, index) => {
+      const props = feature.properties;
+      const coordinates = getLineCoordinates(feature);
+
+      return {
+        id: props.SE_ID?.toString() || `pipeline-${index}`,
+        name: props.SE_VALUE || "Pipeline",
+        type: props.SE_VALUE || "UNKNOWN",
+        diameter: parseInt(props["pipe diameter"] || "0", 10),
+        depth: parseInt(props.depth || props["depth meter"] || "0", 10),
+        status: "normal" as const,
+        material: props.material || "UNKNOWN",
+        coordinates: coordinates.length > 0 ? coordinates : [],
+      };
+    });
+}
+
+/**
+ * Transform GeoJSON features to valve points
+ */
+export function transformValveFeatures(
+  features: GeoJSONFeature[],
+): Array<{
+  id: string;
+  name: string;
+  type: "isolation" | "station" | "control" | "emergency";
+  status: "open" | "closed" | "maintenance" | "fault";
+  segmentId: string;
+  coordinates?: { lat: number; lng: number; elevation?: number };
+  criticality: string;
+}> {
+  return features
+    .filter((feature) => feature.geometry.type === "Point")
+    .map((feature, index) => {
+      const props = feature.properties;
+      const coords = getPointCoordinates(feature);
+
+      // Determine valve type based on properties
+      let valveType: "isolation" | "station" | "control" | "emergency" = "station";
+      if (props.isolation && props.isolation.trim()) {
+        valveType = "isolation";
+      } else if (props["control station"] && props["control station"].trim()) {
+        valveType = "control";
+      }
+
+      return {
+        id: props.SE_ID?.toString() || `valve-${index}`,
+        name: props.SE_VALUE || props["bulb station"] || "Valve",
+        type: valveType,
+        status: "closed" as const,
+        segmentId: "Unknown",
+        coordinates: coords || undefined,
+        criticality: "MEDIUM",
+      };
+    });
+}
+
+/**
+ * Transform GeoJSON features to consumer points
+ */
+export function transformConsumerFeatures(
+  features: GeoJSONFeature[],
+): Array<{
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  type: string;
+  category: string;
+  status: "active" | "inactive";
+  consumerCode?: string;
+  mobile?: string;
+  estimatedConsumption?: number;
+  consumptionUnit?: string;
+}> {
+  return features
+    .filter((feature) => feature.geometry.type === "Point")
+    .map((feature, index) => {
+      const props = feature.properties;
+      const coords = getPointCoordinates(feature);
+
+      if (!coords) {
+        return null;
+      }
+
+      return {
+        id: props.SE_ID?.toString() || `consumer-${index}`,
+        name: props.Consumer_Name || `Consumer ${props.POINT || index}`,
+        lat: coords.lat,
+        lng: coords.lng,
+        type: "CONSUMER",
+        category: props.Category || "DOMESTIC",
+        status: "active" as const,
+        consumerCode: props.Consumer_Code,
+        mobile: props.Mobile,
+        estimatedConsumption: 0,
+        consumptionUnit: "m³/day",
+      };
+    })
+    .filter((item): item is Exclude<typeof item, null> => item !== null);
+}

--- a/src/pages/AssetMenus.tsx
+++ b/src/pages/AssetMenus.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { ValvePointsEditor } from "@/components/ValvePointsEditor";
 import { PipelineNetworkEditor } from "@/components/PipelineNetworkEditor";
+import { ConsumerPointsEditor } from "@/components/ConsumerPointsEditor";
 import CatastropheManagement from "@/components/CatastropheManagement";
 import { CatastrophePointsEditor } from "@/components/CatastrophePointsEditor";
 import apiClient from "@/lib/api";
@@ -87,6 +88,10 @@ export default function AssetMenus() {
       const item = findBy((a) => a.name.toLowerCase() === "catastrophe" || (a.menuName || "").toLowerCase().includes("catastrophe"));
       return { heading: normalizeHeading(item?.menuName || item?.name || "Catastrophe Management"), isCatastropheSurveyElement: item ? item.isSurveyElement : true };
     }
+    if (key === "consumer") {
+        const item = findBy((a) => a.name.toLowerCase() === "consumer" || (a.menuName || "").toLowerCase() === "consumer");
+        return { heading: normalizeHeading(item?.menuName || item?.name || "Consumer"), isCatastropheSurveyElement: null as any };
+    }
     return { heading: normalizeHeading("Pipeline"), isCatastropheSurveyElement: null as any };
   }, [menu, assetTypes]);
 
@@ -130,6 +135,7 @@ export default function AssetMenus() {
           </div>
           {key === "pipeline" && <PipelineNetworkEditor />}
           {key === "valve" && <ValvePointsEditor />}
+          {key === "consumer" && <ConsumerPointsEditor />}
           {key === "catastrophe" && (isCatastropheSurveyElement ? <CatastrophePointsEditor /> : <CatastropheManagement />)}
         </div>
       </main>

--- a/src/pages/FlowlinesMapPage.tsx
+++ b/src/pages/FlowlinesMapPage.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useState, useRef } from "react";
+import { Sidebar } from "@/components/Sidebar";
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+import { useToast } from "@/hooks/use-toast";
+import apiClient from "@/lib/api";
+
+// Fix for default markers in Leaflet with Vite
+delete (L.Icon.Default.prototype as unknown as { _getIconUrl: unknown })._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl:
+    "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png",
+  iconUrl:
+    "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png",
+  shadowUrl:
+    "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png",
+});
+
+const DEFAULT_CENTER: [number, number] = [26.1445, 91.7362];
+const DEFAULT_ZOOM = 13;
+
+interface FlowlineFeature {
+  type: "Feature";
+  geometry: {
+    type: "MultiLineString" | "LineString";
+    coordinates: number[][][] | number[][];
+  };
+  properties: {
+    id: number;
+    depth: number;
+    pipe_diameter: string;
+    shape_length?: number;
+    [key: string]: unknown;
+  };
+}
+
+interface GeoJsonResponse {
+  type: "FeatureCollection";
+  features: FlowlineFeature[];
+}
+
+export default function FlowlinesMapPage() {
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [userRole, setUserRole] = useState<"admin" | "manager" | "survey">("admin");
+  const [isLoading, setIsLoading] = useState(true);
+  const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstanceRef = useRef<L.Map | null>(null);
+  const { toast } = useToast();
+  const flowlinesLayerRef = useRef<L.LayerGroup | null>(null);
+
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem("currentUser");
+      if (raw) {
+        const user = JSON.parse(raw);
+        const roleFromServer = (user?.role as string) || "SURVEY MANAGER";
+        let appRole: "admin" | "manager" | "survey" = "survey";
+        if (roleFromServer === "ADMIN") appRole = "admin";
+        else if (roleFromServer === "MANAGER") appRole = "manager";
+        else appRole = "survey";
+        setUserRole(appRole);
+      }
+    } catch {}
+  }, []);
+
+  const handleLogout = () => {
+    try {
+      sessionStorage.removeItem("currentUser");
+    } catch {}
+    window.location.href = "/";
+  };
+
+  // Initialize map
+  useEffect(() => {
+    if (!mapRef.current || mapInstanceRef.current) return;
+
+    const map = L.map(mapRef.current).setView(DEFAULT_CENTER, DEFAULT_ZOOM);
+
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      attribution: "© OpenStreetMap contributors",
+    }).addTo(map);
+
+    const flowlinesLayer = L.layerGroup().addTo(map);
+    flowlinesLayerRef.current = flowlinesLayer;
+
+    mapInstanceRef.current = map;
+
+    return () => {
+      map.remove();
+      mapInstanceRef.current = null;
+    };
+  }, []);
+
+  // Fetch and display flowlines data
+  useEffect(() => {
+    const fetchFlowlines = async () => {
+      try {
+        setIsLoading(true);
+        const data: GeoJsonResponse = await apiClient.getFlowlines();
+        
+        if (!flowlinesLayerRef.current) return;
+
+        flowlinesLayerRef.current.clearLayers();
+
+        // Track bounds for auto-fit
+        let bounds: L.LatLngBounds | null = null;
+
+        data.features.forEach((feature) => {
+          const { geometry, properties } = feature;
+          
+          if (
+            geometry.type === "MultiLineString" ||
+            (geometry.type === "LineString" && Array.isArray(geometry.coordinates[0]?.[0]))
+          ) {
+            const coordinates = geometry.type === "MultiLineString"
+              ? (geometry.coordinates as number[][][])
+              : [(geometry.coordinates as number[][])];
+
+            coordinates.forEach((lineCoords) => {
+              // Convert GeoJSON coordinates [lng, lat] to Leaflet [lat, lng]
+              const latLngs = lineCoords.map((coord) => [coord[1], coord[0]] as [number, number]);
+
+              if (latLngs.length >= 2) {
+                const diameter = properties.pipe_diameter || "Unknown";
+                const polyline = L.polyline(latLngs, {
+                  color: "#3b82f6",
+                  weight: 4,
+                  opacity: 0.85,
+                });
+
+                polyline.bindPopup(`
+                  <div style="font-family: system-ui; padding: 8px; min-width: 200px;">
+                    <strong>Flowline ${properties.id}</strong><br/>
+                    <span style="color: #666;">Pipe Diameter: ${diameter}mm</span><br/>
+                    <span style="color: #666;">Depth: ${properties.depth}m</span><br/>
+                    ${properties.shape_length ? `<span style="color: #666;">Length: ${(properties.shape_length as number).toFixed(2)}m</span><br/>` : ""}
+                  </div>
+                `);
+
+                flowlinesLayerRef.current?.addLayer(polyline);
+
+                // Track bounds
+                latLngs.forEach((coord) => {
+                  if (!bounds) {
+                    bounds = L.latLngBounds(coord, coord);
+                  } else {
+                    bounds.extend(coord);
+                  }
+                });
+              }
+            });
+          }
+        });
+
+        // Auto-fit map to bounds
+        if (bounds && mapInstanceRef.current) {
+          mapInstanceRef.current.fitBounds(bounds, { padding: [32, 32], maxZoom: 17 });
+        }
+
+        toast({
+          title: "Success",
+          description: `Loaded ${data.features.length} flowlines`,
+        });
+      } catch (error) {
+        console.error("Failed to fetch flowlines:", error);
+        toast({
+          title: "Error",
+          description: "Failed to load flowlines. Please check the API endpoint.",
+          variant: "destructive",
+        });
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchFlowlines();
+  }, [toast]);
+
+  const activeTab = "flowlines";
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Sidebar
+        activeTab={activeTab}
+        onTabChange={() => {}}
+        userRole={userRole}
+        onLogout={handleLogout}
+        onCollapsedChange={setSidebarCollapsed}
+      />
+      <main className={`transition-all duration-300 ${sidebarCollapsed ? "ml-16" : "ml-64"}`}>
+        <div className="w-full h-screen flex flex-col">
+          <div className="flex-1 relative">
+            {isLoading && (
+              <div className="absolute inset-0 bg-background/50 backdrop-blur-sm flex items-center justify-center z-50">
+                <div className="text-center">
+                  <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+                  <p className="text-muted-foreground">Loading flowlines...</p>
+                </div>
+              </div>
+            )}
+            <div ref={mapRef} className="w-full h-full rounded-lg leaflet-container" />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,6 +9,7 @@ import { DeviceStatus } from "@/components/DeviceStatus";
 import { DailyPersonalMaps } from "./DailyPersonalMaps";
 import { PipelineNetworkEditor } from "@/components/PipelineNetworkEditor";
 import { ValvePointsEditor } from "@/components/ValvePointsEditor";
+import { ConsumerPointsEditor } from "@/components/ConsumerPointsEditor";
 import CatastropheManagement from "@/components/CatastropheManagement";
 import ValveOperationLog from "@/components/ValveOperationLog";
 import { ReportsDashboard } from "@/components/ReportsDashboard";
@@ -110,6 +111,8 @@ const Index = () => {
         return <PipelineNetworkEditor />;
       case "valve-editor":
         return <ValvePointsEditor />;
+      case "consumer-editor":
+        return <ConsumerPointsEditor />;
       case "catastrophe":
         return <CatastropheManagement />;
       case "valve-operations":

--- a/src/pages/ValvesMapPage.tsx
+++ b/src/pages/ValvesMapPage.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useState, useRef } from "react";
+import { Sidebar } from "@/components/Sidebar";
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+import { useToast } from "@/hooks/use-toast";
+import apiClient from "@/lib/api";
+
+// Fix for default markers in Leaflet with Vite
+delete (L.Icon.Default.prototype as unknown as { _getIconUrl: unknown })._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl:
+    "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png",
+  iconUrl:
+    "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png",
+  shadowUrl:
+    "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png",
+});
+
+const DEFAULT_CENTER: [number, number] = [26.1445, 91.7362];
+const DEFAULT_ZOOM = 13;
+
+interface ValveFeature {
+  type: "Feature";
+  geometry: {
+    type: "Point";
+    coordinates: [number, number];
+  };
+  properties: {
+    id: number;
+    bulb: string;
+    control: string;
+    service: string;
+    isolation: string;
+    [key: string]: unknown;
+  };
+}
+
+interface GeoJsonResponse {
+  type: "FeatureCollection";
+  features: ValveFeature[];
+}
+
+export default function ValvesMapPage() {
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [userRole, setUserRole] = useState<"admin" | "manager" | "survey">("admin");
+  const [isLoading, setIsLoading] = useState(true);
+  const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstanceRef = useRef<L.Map | null>(null);
+  const { toast } = useToast();
+  const valvesLayerRef = useRef<L.LayerGroup | null>(null);
+
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem("currentUser");
+      if (raw) {
+        const user = JSON.parse(raw);
+        const roleFromServer = (user?.role as string) || "SURVEY MANAGER";
+        let appRole: "admin" | "manager" | "survey" = "survey";
+        if (roleFromServer === "ADMIN") appRole = "admin";
+        else if (roleFromServer === "MANAGER") appRole = "manager";
+        else appRole = "survey";
+        setUserRole(appRole);
+      }
+    } catch {}
+  }, []);
+
+  const handleLogout = () => {
+    try {
+      sessionStorage.removeItem("currentUser");
+    } catch {}
+    window.location.href = "/";
+  };
+
+  // Initialize map
+  useEffect(() => {
+    if (!mapRef.current || mapInstanceRef.current) return;
+
+    const map = L.map(mapRef.current).setView(DEFAULT_CENTER, DEFAULT_ZOOM);
+
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      attribution: "© OpenStreetMap contributors",
+    }).addTo(map);
+
+    const valvesLayer = L.layerGroup().addTo(map);
+    valvesLayerRef.current = valvesLayer;
+
+    mapInstanceRef.current = map;
+
+    return () => {
+      map.remove();
+      mapInstanceRef.current = null;
+    };
+  }, []);
+
+  // Fetch and display valves data
+  useEffect(() => {
+    const fetchValves = async () => {
+      try {
+        setIsLoading(true);
+        const data: GeoJsonResponse = await apiClient.getValves();
+
+        if (!valvesLayerRef.current) return;
+
+        valvesLayerRef.current.clearLayers();
+
+        // Track bounds for auto-fit
+        let bounds: L.LatLngBounds | null = null;
+
+        data.features.forEach((feature) => {
+          const { geometry, properties } = feature;
+
+          if (geometry.type === "Point") {
+            const [lng, lat] = geometry.coordinates;
+
+            const marker = L.circleMarker([lat, lng], {
+              radius: 8,
+              fillColor: "#ef4444",
+              color: "white",
+              weight: 2,
+              opacity: 1,
+              fillOpacity: 0.8,
+            });
+
+            marker.bindPopup(`
+              <div style="font-family: system-ui; padding: 8px; min-width: 220px;">
+                <strong>Valve ${properties.id}</strong><br/>
+                <span style="color: #666;">Bulb: ${properties.bulb || "N/A"}</span><br/>
+                ${properties.control ? `<span style="color: #666;">Control: ${properties.control}</span><br/>` : ""}
+                ${properties.service ? `<span style="color: #666;">Service: ${properties.service}</span><br/>` : ""}
+                ${properties.isolation ? `<span style="color: #666;">Isolation: ${properties.isolation}</span><br/>` : ""}
+              </div>
+            `);
+
+            valvesLayerRef.current?.addLayer(marker);
+
+            // Track bounds
+            if (!bounds) {
+              bounds = L.latLngBounds([lat, lng], [lat, lng]);
+            } else {
+              bounds.extend([lat, lng]);
+            }
+          }
+        });
+
+        // Auto-fit map to bounds
+        if (bounds && mapInstanceRef.current) {
+          mapInstanceRef.current.fitBounds(bounds, { padding: [32, 32], maxZoom: 17 });
+        }
+
+        toast({
+          title: "Success",
+          description: `Loaded ${data.features.length} valves`,
+        });
+      } catch (error) {
+        console.error("Failed to fetch valves:", error);
+        toast({
+          title: "Error",
+          description: "Failed to load valves. Please check the API endpoint.",
+          variant: "destructive",
+        });
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchValves();
+  }, [toast]);
+
+  const activeTab = "valves";
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Sidebar
+        activeTab={activeTab}
+        onTabChange={() => {}}
+        userRole={userRole}
+        onLogout={handleLogout}
+        onCollapsedChange={setSidebarCollapsed}
+      />
+      <main className={`transition-all duration-300 ${sidebarCollapsed ? "ml-16" : "ml-64"}`}>
+        <div className="w-full h-screen flex flex-col">
+          <div className="flex-1 relative">
+            {isLoading && (
+              <div className="absolute inset-0 bg-background/50 backdrop-blur-sm flex items-center justify-center z-50">
+                <div className="text-center">
+                  <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+                  <p className="text-muted-foreground">Loading valves...</p>
+                </div>
+              </div>
+            )}
+            <div ref={mapRef} className="w-full h-full rounded-lg leaflet-container" />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
### Summary
Updates the Map Dashboard to display pipeline networks, valve/isolation points, and consumer points fetched from the `AssetProperties/ByType` API endpoint, replacing mock data and irrelevant layer controls.

### Problem
The Map Dashboard previously used mock data and displayed unrelated asset types (devices, control stations, underground/above-ground sub-filters). The left-hand panel had too many toggle options and did not reflect the three core asset categories needed: Pipeline Network, Valve Stations & Isolation Points, and Consumer Points.

### Solution
Replaced mock data sources and device-centric hooks with new API-driven hooks (`useAssetPropertiesByType` and `useConsumerPoints`) that call the `AssetProperties/ByType/{type}` endpoint. The layer toggle panel was simplified to only three toggles, and the map and sidebar panels were updated to reflect the new data model.

### Key Changes
- **New API hooks** (`useAssetPropertiesByType`, `useConsumerPoints`) added to `useApiQueries.ts`, querying `/api/AssetProperties/ByType/{pipeline|valve|consumer}`
- **Removed mock data** (`mockInfrastructurePipelines`, `mockInfrastructureValves`, `mockControlStations`) and replaced with live API responses
- **Simplified layer toggles** to three options: Pipeline Network, Valve Stations & Isolation Points, and Consumer Points (removed devices, control stations, underground/above-ground/service sub-filters)
- **Added `ConsumerPoint` interface** and transformation logic to map API consumer data to map-compatible format, filtering out entries with invalid coordinates
- **Updated pipeline and valve transforms** to map API response fields (e.g., `specifications.diameter`, `installation.depthBelowGround`) to the existing `PipelineSegment` and `ValvePoint` interfaces
- **Updated Infrastructure Status overlay** to show Pipelines count, Operational Valves count, and Consumer Points count
- **Updated Asset Symbology legend** to reflect Pipeline, Valve/Isolation Point, and Consumer Point symbols


---

<a href="https://builder.io/app/projects/02ab808518874468afc2382ec8d0ac9f/silent-tie-dqkpivpx"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://02ab808518874468afc2382ec8d0ac9f-silent-tie-dqkpivpx_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 207`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>02ab808518874468afc2382ec8d0ac9f</projectId>-->
<!--<branchName>silent-tie-dqkpivpx</branchName>-->