### PR TITLE
Use consumers object to render consumer points in RGISMap

### DIFF
--- a/src/components/RGISMap.tsx
+++ b/src/components/RGISMap.tsx
@@ -308,6 +308,39 @@ export const RGISMap = ({
       });
     }
 
+    if (showConsumers) {
+      consumers.forEach((consumer) => {
+        if (consumer.coordinates.lat === undefined || consumer.coordinates.lng === undefined) return;
+
+        const pt = new Point({
+          longitude: consumer.coordinates.lng,
+          latitude: consumer.coordinates.lat,
+        });
+        allPoints.push(pt);
+
+        const markerSymbol = {
+          type: "simple-marker",
+          color: [251, 146, 60], // orange-400
+          outline: {
+            color: [255, 255, 255],
+            width: 2,
+          },
+        };
+
+        const graphic = new Graphic({
+          geometry: pt,
+          symbol: markerSymbol as any,
+          attributes: consumer,
+          popupTemplate: {
+            title: consumer.name ?? `Consumer ${consumer.id}`,
+            content: "Code: {code}<br>Mobile: {mobile}<br>Status: {status}",
+          },
+        });
+
+        graphicsLayer.add(graphic);
+      });
+    }
+
     // Zoom to fit all graphics
     if (allPoints.length > 0) {
         view.when(() => {
@@ -315,7 +348,7 @@ export const RGISMap = ({
         });
     }
 
-  }, [devices, pipelines, valves, showDevices, showPipelines, showValves]);
+  }, [devices, pipelines, valves, consumers, showDevices, showPipelines, showValves, showConsumers]);
 
   return (
     <div className="w-full h-full relative">


### PR DESCRIPTION
### Summary
Replaces the use of the `devices` object for rendering consumer points in `RGISMap.tsx` with the dedicated `consumers` object, controlled by a `showConsumers` flag — consistent with how the Leaflet map handles consumer rendering.

### Problem
Consumer points in `RGISMap.tsx` were being driven by the `devices` object rather than the `consumers` object. This was semantically incorrect and inconsistent with the Leaflet map implementation, which uses a dedicated `consumers` data source and a `showConsumers` toggle.

### Solution
Added a dedicated block in the graphics rendering logic that iterates over the `consumers` array when `showConsumers` is `true`, plots each consumer as a map graphic with an orange marker, and includes a popup template with consumer details. The `useEffect` dependency array was also updated to include `consumers` and `showConsumers`.

### Key Changes
- Added a `showConsumers`-gated loop over the `consumers` array to render consumer points as `Graphic` objects on the ArcGIS graphics layer
- Each consumer graphic uses an orange (`[251, 146, 60]`) simple-marker symbol with a white outline, matching a visually distinct style
- Popup template displays consumer `name`/`id` as title, and `code`, `mobile`, and `status` as content
- Consumer coordinates are validated before rendering (skips entries with undefined `lat`/`lng`)
- Updated `useEffect` dependency array to include `consumers` and `showConsumers` to ensure reactivity on changes


---

<a href="https://builder.io/app/projects/9a64579b123d414ea0062614b8bad802/macro-melody-osw1ha1t"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://9a64579b123d414ea0062614b8bad802-macro-melody-osw1ha1t_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 213`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9a64579b123d414ea0062614b8bad802</projectId>-->
<!--<branchName>macro-melody-osw1ha1t</branchName>-->