### PR TITLE
Add RGIS map layers to CatastrophePointsEditor

### DIFF
--- a/src/components/CatastrophePointsEditor.tsx
+++ b/src/components/CatastrophePointsEditor.tsx
@@ -1,5 +1,9 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { LeafletMap } from "@/components/LeafletMap";
+import { RGISMap } from "@/components/RGISMap";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
 import {
   Table,
   TableBody,
@@ -11,11 +15,17 @@ import {
 import { SortableTableHead } from "@/components/ui/sortable-table-head";
 import { Pagination } from "@/components/ui/pagination";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { MapPin, AlertTriangle } from "lucide-react";
+import { MapPin, AlertTriangle, Layers, RefreshCw } from "lucide-react";
 import { useTable } from "@/hooks/use-table";
 import { useEffect, useMemo, useState } from "react";
-import { useDeviceLogs } from "@/hooks/useApiQueries";
+import { useDeviceLogs, usePipelineGeoJSON, useValveGeoJSON, useConsumerGeoJSON } from "@/hooks/useApiQueries";
 import { API_BASE_PATH } from "@/lib/api";
+import {
+  parseGeoJSON,
+  transformPipelineFeatures,
+  transformValveFeatures,
+  transformConsumerFeatures,
+} from "@/lib/geoJsonParser";
 
 // Dynamic row type for arbitrary property names
 type DynamicRow = Record<string, any>;
@@ -48,6 +58,41 @@ interface MapCatastrophe {
   coordinates?: { lat: number; lng: number };
 }
 
+interface PipelineSegment {
+  id: string;
+  name?: string;
+  type?: string;
+  diameter: number;
+  depth: number;
+  status: "normal" | "warning" | "critical" | "maintenance";
+  material?: string;
+  coordinates?: Array<{ lat: number; lng: number; elevation?: number }>;
+}
+
+interface ValvePoint {
+  id: string;
+  name?: string;
+  type: "control" | "emergency" | "isolation" | "station";
+  status: "open" | "closed" | "maintenance" | "fault";
+  segmentId: string;
+  coordinates?: { lat: number; lng: number; elevation?: number };
+  criticality?: string;
+}
+
+interface ConsumerPoint {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  type: string;
+  category?: string;
+  status?: "active" | "inactive";
+  estimatedConsumption?: number;
+  consumptionUnit?: string;
+  consumerCode?: string;
+  mobile?: string;
+}
+
 export const CatastrophePointsEditor = () => {
   const [rows, setRows] = useState<DynamicRow[]>([]);
   const [columns, setColumns] = useState<string[]>([]);
@@ -57,6 +102,34 @@ export const CatastrophePointsEditor = () => {
   // Pipelines state and error
   const [pipelineRows, setPipelineRows] = useState<DynamicRow[]>([]);
   const [pipelineError, setPipelineError] = useState<string | null>(null);
+
+  // Map type and layer controls
+  const [showRGIS, setShowRGIS] = useState(true);
+  const [showPipelines, setShowPipelines] = useState(true);
+  const [showValves, setShowValves] = useState(true);
+  const [showConsumerPoints, setShowConsumerPoints] = useState(true);
+
+  // API hooks - fetch GeoJSON from survey-geojson endpoint
+  const {
+    data: pipelinesGeoJSON,
+    isLoading: loadingPipelinesGeoJSON,
+    error: pipelinesGeoJSONError,
+    refetch: refetchPipelines,
+  } = usePipelineGeoJSON();
+
+  const {
+    data: valvesGeoJSON,
+    isLoading: loadingValvesGeoJSON,
+    error: valvesGeoJSONError,
+    refetch: refetchValves,
+  } = useValveGeoJSON();
+
+  const {
+    data: consumerGeoJSON,
+    isLoading: loadingConsumerGeoJSON,
+    error: consumerGeoJSONError,
+    refetch: refetchConsumerPoints,
+  } = useConsumerGeoJSON();
 
   // Load pipelines for map layer from required endpoint
   useEffect(() => {
@@ -104,6 +177,48 @@ export const CatastrophePointsEditor = () => {
       lastPing: device.lastSeen || "Unknown",
     }));
   }, [deviceLogsResponse]);
+
+  // Transform pipeline GeoJSON data
+  const transformedPipelines: PipelineSegment[] = useMemo(() => {
+    if (!showPipelines || !pipelinesGeoJSON?.data) return [];
+
+    const geoJsonString = pipelinesGeoJSON.data;
+    const featureCollection = parseGeoJSON(geoJsonString);
+
+    if (!featureCollection || !featureCollection.features) {
+      return [];
+    }
+
+    return transformPipelineFeatures(featureCollection.features);
+  }, [pipelinesGeoJSON?.data, showPipelines]);
+
+  // Transform valve GeoJSON data
+  const transformedValves: ValvePoint[] = useMemo(() => {
+    if (!showValves || !valvesGeoJSON?.data) return [];
+
+    const geoJsonString = valvesGeoJSON.data;
+    const featureCollection = parseGeoJSON(geoJsonString);
+
+    if (!featureCollection || !featureCollection.features) {
+      return [];
+    }
+
+    return transformValveFeatures(featureCollection.features);
+  }, [valvesGeoJSON?.data, showValves]);
+
+  // Transform consumer GeoJSON data
+  const transformedConsumerPoints: ConsumerPoint[] = useMemo(() => {
+    if (!showConsumerPoints || !consumerGeoJSON?.data) return [];
+
+    const geoJsonString = consumerGeoJSON.data;
+    const featureCollection = parseGeoJSON(geoJsonString);
+
+    if (!featureCollection || !featureCollection.features) {
+      return [];
+    }
+
+    return transformConsumerFeatures(featureCollection.features);
+  }, [consumerGeoJSON?.data, showConsumerPoints]);
 
   // Pipelines mapped minimally for LeafletMap (geometry may fall back to defaults)
   const mapPipelines: MapPipelineSegment[] = useMemo(() => {
@@ -160,6 +275,16 @@ export const CatastrophePointsEditor = () => {
   const defaultSortKey = (columns.includes("id") ? "id" : columns[0]) as keyof DynamicRow | undefined;
   const { tableConfig, sortedAndPaginatedData } = useTable<DynamicRow>(rows, 5, defaultSortKey as any);
 
+  const handleRefresh = () => {
+    refetchPipelines();
+    refetchValves();
+    refetchConsumerPoints();
+  };
+
+  const isLoading =
+    loadingPipelinesGeoJSON || loadingValvesGeoJSON || loadingConsumerGeoJSON;
+  const hasError = pipelinesGeoJSONError || valvesGeoJSONError || consumerGeoJSONError;
+
   // Derive simple valves for map layer from dynamic rows (best-effort mapping)
   const mapValves: MapValve[] = useMemo(() => {
     return rows.map((r, idx) => {
@@ -215,96 +340,200 @@ export const CatastrophePointsEditor = () => {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <MapPin className="h-5 w-5" />
-              Catastrophe Points ({rows.length})
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="p-0">
-            <div className="p-6 pb-0">
-              {error && (
-                <Alert variant="destructive" className="mb-4">
-                  <AlertTriangle className="h-4 w-4" />
-                  <AlertDescription>{error}</AlertDescription>
-                </Alert>
-              )}
-              {loading ? (
-                <div className="text-sm text-muted-foreground">Loading...</div>
-              ) : (
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      {columns.length === 0 ? (
-                        <TableHead>No data</TableHead>
-                      ) : (
-                        columns.map((col) => (
-                          <SortableTableHead
-                            key={col}
-                            sortKey={col}
-                            currentSortKey={tableConfig.sortConfig.key as unknown as string}
-                            sortDirection={tableConfig.sortConfig.direction}
-                            onSort={(k) => tableConfig.handleSort(k as keyof DynamicRow)}
-                          >
-                            {col}
-                          </SortableTableHead> 
-                        ))
-                      )}
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {sortedAndPaginatedData.map((row, idx) => (
-                      <TableRow key={String(row.id ?? idx)}>
-                        {columns.map((col) => {
-                          const value = row[col];
-                          return (
-                            <TableCell key={col}>
-                              {value === null || value === undefined || value === "" ? "-" : String(value)}
-                            </TableCell>
-                          );
-                        })}
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              )}
-            </div>
-            <Pagination
-              config={tableConfig.paginationConfig}
-              onPageChange={tableConfig.setCurrentPage}
-              onPageSizeChange={tableConfig.setPageSize}
-              onFirstPage={tableConfig.goToFirstPage}
-              onLastPage={tableConfig.goToLastPage}
-              onNextPage={tableConfig.goToNextPage}
-              onPreviousPage={tableConfig.goToPreviousPage}
-              canGoNext={tableConfig.canGoNext}
-              canGoPrevious={tableConfig.canGoPrevious}
-              pageSizeOptions={[5, 10, 20]}
-            />
-          </CardContent>
-        </Card>
+      {hasError && (
+        <Alert variant="destructive" className="mb-4">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription>API Connection Issue - Data may be incomplete or unavailable</AlertDescription>
+        </Alert>
+      )}
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Network Map</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="h-96">
-              <LeafletMap
-                devices={mapDevices}
-                pipelines={mapPipelines}
-                valves={mapValves}
-                showDevices={mapDevices.length > 0}
-                showPipelines={mapPipelines.length > 0}
-                showValves={mapValves.length > 0}
-                catastrophes={mapCatastrophes}
-                showCatastrophes={mapCatastrophes.some((c) => c.coordinates && Number.isFinite(c.coordinates.lat) && Number.isFinite(c.coordinates.lng))}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Layer Controls Sidebar */}
+        <div className="space-y-4">
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-lg flex items-center">
+                <Layers className="w-5 h-5 mr-2" />
+                Infrastructure Assets
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {/* Map Type Control */}
+              <div className="flex items-center justify-between border-b pb-3 mb-3">
+                <Label htmlFor="rgis-map" className="text-base font-semibold">
+                  Map Type
+                </Label>
+                <Switch
+                  id="rgis-map"
+                  checked={showRGIS}
+                  onCheckedChange={setShowRGIS}
+                />
+              </div>
+              <div className="text-xs text-muted-foreground mb-3">
+                {showRGIS ? "RGIS Map" : "Leaflet Map"}
+              </div>
+
+              {/* Pipeline Controls */}
+              <div className="flex items-center justify-between">
+                <Label htmlFor="pipelines" className="flex items-center space-x-2">
+                  <div className="w-3 h-3 bg-blue-500 rounded-full"></div>
+                  <span>Pipeline Network</span>
+                </Label>
+                <Switch
+                  id="pipelines"
+                  checked={showPipelines}
+                  onCheckedChange={setShowPipelines}
+                />
+              </div>
+
+              {/* Valve Controls */}
+              <div className="flex items-center justify-between">
+                <Label htmlFor="valves" className="flex items-center space-x-2">
+                  <div className="w-3 h-3 bg-orange-500 rounded-full"></div>
+                  <span>Valve Stations</span>
+                </Label>
+                <Switch
+                  id="valves"
+                  checked={showValves}
+                  onCheckedChange={setShowValves}
+                />
+              </div>
+
+              {/* Consumer Points Controls */}
+              <div className="flex items-center justify-between">
+                <Label
+                  htmlFor="consumer-points"
+                  className="flex items-center space-x-2"
+                >
+                  <div className="w-3 h-3 bg-purple-500 rounded-full"></div>
+                  <span>Consumer Points</span>
+                </Label>
+                <Switch
+                  id="consumer-points"
+                  checked={showConsumerPoints}
+                  onCheckedChange={setShowConsumerPoints}
+                />
+              </div>
+
+              <Button
+                onClick={handleRefresh}
+                className="w-full"
+                disabled={isLoading}
+              >
+                <RefreshCw
+                  className={`w-4 h-4 mr-2 ${isLoading ? "animate-spin" : ""}`}
+                />
+                {isLoading ? "Loading..." : "Refresh Map"}
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Table and Map */}
+        <div className="lg:col-span-2 space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <MapPin className="h-5 w-5" />
+                Catastrophe Points ({rows.length})
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="p-0">
+              <div className="p-6 pb-0">
+                {error && (
+                  <Alert variant="destructive" className="mb-4">
+                    <AlertTriangle className="h-4 w-4" />
+                    <AlertDescription>{error}</AlertDescription>
+                  </Alert>
+                )}
+                {loading ? (
+                  <div className="text-sm text-muted-foreground">Loading...</div>
+                ) : (
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        {columns.length === 0 ? (
+                          <TableHead>No data</TableHead>
+                        ) : (
+                          columns.map((col) => (
+                            <SortableTableHead
+                              key={col}
+                              sortKey={col}
+                              currentSortKey={tableConfig.sortConfig.key as unknown as string}
+                              sortDirection={tableConfig.sortConfig.direction}
+                              onSort={(k) => tableConfig.handleSort(k as keyof DynamicRow)}
+                            >
+                              {col}
+                            </SortableTableHead>
+                          ))
+                        )}
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {sortedAndPaginatedData.map((row, idx) => (
+                        <TableRow key={String(row.id ?? idx)}>
+                          {columns.map((col) => {
+                            const value = row[col];
+                            return (
+                              <TableCell key={col}>
+                                {value === null || value === undefined || value === "" ? "-" : String(value)}
+                              </TableCell>
+                            );
+                          })}
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                )}
+              </div>
+              <Pagination
+                config={tableConfig.paginationConfig}
+                onPageChange={tableConfig.setCurrentPage}
+                onPageSizeChange={tableConfig.setPageSize}
+                onFirstPage={tableConfig.goToFirstPage}
+                onLastPage={tableConfig.goToLastPage}
+                onNextPage={tableConfig.goToNextPage}
+                onPreviousPage={tableConfig.goToPreviousPage}
+                canGoNext={tableConfig.canGoNext}
+                canGoPrevious={tableConfig.canGoPrevious}
+                pageSizeOptions={[5, 10, 20]}
               />
-            </div>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Network Map</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="h-96">
+                {showRGIS ? (
+                  <RGISMap
+                    devices={transformedConsumerPoints as unknown as any[]}
+                    pipelines={transformedPipelines}
+                    valves={transformedValves}
+                    consumers={transformedConsumerPoints}
+                    showDevices={showConsumerPoints}
+                    showPipelines={showPipelines}
+                    showValves={showValves}
+                    showConsumers={showConsumerPoints}
+                  />
+                ) : (
+                  <LeafletMap
+                    devices={mapDevices}
+                    pipelines={mapPipelines}
+                    valves={mapValves}
+                    showDevices={mapDevices.length > 0}
+                    showPipelines={showPipelines}
+                    showValves={showValves}
+                    catastrophes={mapCatastrophes}
+                    showCatastrophes={mapCatastrophes.some((c) => c.coordinates && Number.isFinite(c.coordinates.lat) && Number.isFinite(c.coordinates.lng))}
+                  />
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
### Summary
Adds RGIS map support to the `CatastrophePointsEditor` page, enabling it to display pipelines, valves, and consumer points — matching the functionality already available on the map dashboard page.

### Problem
The `CatastrophePointsEditor` page previously only rendered a basic `LeafletMap` without pipeline, valve, or consumer point layers. Users had no way to visualize infrastructure assets (pipelines, valves, consumers) in the context of catastrophe points, unlike the map dashboard which supported full RGIS layer rendering.

### Solution
Integrated the `RGISMap` component and its associated GeoJSON data hooks into `CatastrophePointsEditor`, along with a layer controls sidebar that mirrors the `showRGIS` toggle pattern from the map dashboard. Users can now switch between RGIS and Leaflet map views and toggle individual infrastructure layers on or off.

### Key Changes
- **Added `RGISMap` component** as the primary map renderer, with `LeafletMap` retained as a fallback when RGIS mode is toggled off.
- **Integrated GeoJSON API hooks** (`usePipelineGeoJSON`, `useValveGeoJSON`, `useConsumerGeoJSON`) to fetch live infrastructure data.
- **Added GeoJSON transformation logic** using `parseGeoJSON`, `transformPipelineFeatures`, `transformValveFeatures`, and `transformConsumerFeatures` from `geoJsonParser`.
- **Added a layer controls sidebar** with toggle switches for map type (RGIS vs. Leaflet), pipeline network, valve stations, and consumer points visibility.
- **Added a Refresh button** that re-fetches all GeoJSON data sources, with a loading spinner indicator.
- **Added error alert** at the page level to surface API connection issues when any GeoJSON fetch fails.
- **Defined local TypeScript interfaces** (`PipelineSegment`, `ValvePoint`, `ConsumerPoint`) to type the transformed GeoJSON data.
- **Restructured layout** from a 2-column grid to a 3-column grid, with the controls sidebar occupying one column and the table/map spanning the remaining two.


---

<a href="https://builder.io/app/projects/9a64579b123d414ea0062614b8bad802/chrome-pace-gwgg53wx"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://9a64579b123d414ea0062614b8bad802-chrome-pace-gwgg53wx_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 214`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9a64579b123d414ea0062614b8bad802</projectId>-->
<!--<branchName>chrome-pace-gwgg53wx</branchName>-->