### PR TITLE
Populate Catastrophe grid and map from GeoJSON API

### DIFF
--- a/src/components/CatastropheManagement.tsx
+++ b/src/components/CatastropheManagement.tsx
@@ -19,6 +19,7 @@ import {
   usePipelineGeoJSON,
   useValveGeoJSON,
   useConsumerGeoJSON,
+  useCatastropheGeoJSON,
   useCreateCatastrophe,
   useUpdateCatastrophe,
 } from "@/hooks/useApiQueries";
@@ -27,6 +28,7 @@ import {
   transformPipelineFeatures,
   transformValveFeatures,
   transformConsumerFeatures,
+  transformCatastropheFeatures,
 } from "@/lib/geoJsonParser";
 import apiClient from "@/lib/api";
 import { toast } from "sonner";
@@ -72,6 +74,13 @@ const CatastropheManagement = () => {
     error: consumerPointsError,
     refetch: refetchConsumerPoints,
   } = useConsumerGeoJSON();
+
+  const {
+    data: catastropheGeoJSON,
+    isLoading: loadingCatastropheGeoJSON,
+    error: catastropheGeoJSONError,
+    refetch: refetchCatastropheGeoJSON,
+  } = useCatastropheGeoJSON();
 
   const createCatastropheMutation = useCreateCatastrophe();
   const updateCatastropheMutation = useUpdateCatastrophe();
@@ -278,15 +287,48 @@ const CatastropheManagement = () => {
     return transformConsumerFeatures(featureCollection.features);
   }, [consumerGeoJSON?.data]);
 
+  // Transform catastrophe GeoJSON data for map display
+  const mapCatastrophes = useMemo(() => {
+    if (!catastropheGeoJSON?.data) return [];
+
+    const geoJsonString = catastropheGeoJSON.data;
+    const featureCollection = parseGeoJSON(geoJsonString);
+
+    if (!featureCollection || !featureCollection.features) {
+      return [];
+    }
+
+    return transformCatastropheFeatures(featureCollection.features);
+  }, [catastropheGeoJSON?.data]);
+
+  // Update catastrophes grid to use GeoJSON data
+  useEffect(() => {
+    if (mapCatastrophes.length > 0) {
+      const geoJsonCatastrophes: Catastrophe[] = mapCatastrophes.map((cat) => ({
+        id: cat.id,
+        segmentId: "Unknown",
+        type: cat.type,
+        description: cat.description,
+        location: {
+          lat: cat.lat,
+          lng: cat.lng,
+          address: `${cat.lat.toFixed(4)}, ${cat.lng.toFixed(4)}`,
+        },
+        reportedDate: cat.reportedDate ? new Date(cat.reportedDate) : null,
+      }));
+      setCatastrophes(geoJsonCatastrophes);
+    }
+  }, [mapCatastrophes]);
+
   const handleRefresh = () => {
-    fetchCatastrophes();
+    refetchCatastropheGeoJSON();
     refetchPipelines();
     refetchValves();
     refetchConsumerPoints();
   };
 
   const isLoading =
-    loadingCatastrophes || loadingPipelines || loadingValves || loadingConsumerPoints;
+    loadingCatastropheGeoJSON || loadingPipelines || loadingValves || loadingConsumerPoints;
 
   return (
     <div className="p-6 space-y-6">
@@ -463,13 +505,14 @@ const CatastropheManagement = () => {
                     showDevices={false}
                     showPipelines={mapPipelines.some(p => (p.coordinates?.length ?? 0) >= 2)}
                     showValves={mapValves.some(v => !!v.coordinates)}
-                    catastrophes={catastrophes.map((c) => ({
+                    catastrophes={mapCatastrophes.map((c) => ({
                       id: c.id,
                       name: c.type,
-                      coordinates: { lat: c.location.lat, lng: c.location.lng },
+                      severity: c.severity,
+                      coordinates: { lat: c.lat, lng: c.lng },
                       description: c.description,
                     }))}
-                    showCatastrophes={true}
+                    showCatastrophes={mapCatastrophes.length > 0}
                     onMapClick={handleMapClick}
                     selectedLocation={selectedLocation}
                     disableAutoFit={!!selectedLocation}

--- a/src/hooks/useApiQueries.ts
+++ b/src/hooks/useApiQueries.ts
@@ -610,7 +610,7 @@ export function useAssetPropertiesByType(type: string) {
 }
 
 // Survey GeoJSON hooks
-export function useSurveyGeoJSON(atName: "PipeLine" | "Valve" | "Consumer") {
+export function useSurveyGeoJSON(atName: "PipeLine" | "Valve" | "Consumer" | "Catastrophe") {
   return useQuery({
     queryKey: ["surveyGeoJSON", atName],
     queryFn: () => apiClient.getSurveyGeoJson(atName),
@@ -637,4 +637,8 @@ export function useConsumerPoints() {
     queryFn: () => apiClient.getAssetPropertiesByType("consumer"),
     staleTime: 5 * 60 * 1000,
   });
+}
+
+export function useCatastropheGeoJSON() {
+  return useSurveyGeoJSON("Catastrophe");
 }

--- a/src/lib/geoJsonParser.ts
+++ b/src/lib/geoJsonParser.ts
@@ -198,3 +198,53 @@ export function transformConsumerFeatures(
     })
     .filter((item): item is Exclude<typeof item, null> => item !== null);
 }
+
+/**
+ * Transform GeoJSON features to catastrophe points
+ */
+export function transformCatastropheFeatures(
+  features: GeoJSONFeature[],
+): Array<{
+  id: string;
+  type: string;
+  description: string;
+  lat: number;
+  lng: number;
+  severity: "low" | "medium" | "high" | "critical";
+  reportedDate: string;
+  point: number;
+}> {
+  return features
+    .filter((feature) => feature.geometry.type === "Point")
+    .map((feature, index) => {
+      const props = feature.properties;
+      const coords = getPointCoordinates(feature);
+
+      if (!coords) {
+        return null;
+      }
+
+      // Determine severity based on type or properties
+      let severity: "low" | "medium" | "high" | "critical" = "medium";
+      const catastropheType = props.Type || props.SE_VALUE || "UNKNOWN";
+      if (catastropheType === "BLOCKAGE") {
+        severity = "high";
+      } else if (catastropheType === "BREAK" || catastropheType === "BURST") {
+        severity = "critical";
+      } else if (catastropheType === "LEAK") {
+        severity = "medium";
+      }
+
+      return {
+        id: props.SE_ID?.toString() || `catastrophe-${index}`,
+        type: catastropheType,
+        description: props.Description || props.SE_VALUE || "No description provided",
+        lat: coords.lat,
+        lng: coords.lng,
+        severity,
+        reportedDate: props.SE_ENTRY_DATE || new Date().toISOString(),
+        point: props.POINT || index,
+      };
+    })
+    .filter((item): item is Exclude<typeof item, null> => item !== null);
+}


### PR DESCRIPTION
### Summary
Integrates the Catastrophe survey GeoJSON API to populate both the data grid and the map in the Catastrophe Management page, consistent with how Valve, Pipeline, and Consumer pages work.

### Problem
The Catastrophe Management page was not fetching or displaying data from the survey GeoJSON API (`/api/SurveyEntries/survey-geojson?atName=Catastrophe`). The grid was not populated from the API, catastrophe points were not rendered on the map alongside valves, pipelines, and consumers, and the `Catastrophe` type was not supported by the shared GeoJSON hook — which could also cause errors on other pages' maps.

### Solution
Added a dedicated `useCatastropheGeoJSON` hook that reuses the existing `useSurveyGeoJSON` infrastructure with the `"Catastrophe"` asset type. A new `transformCatastropheFeatures` parser was implemented to convert GeoJSON features into typed catastrophe objects with severity inference. The component was updated to drive both the grid and the map from this GeoJSON data.

### Key Changes
- **`useApiQueries.ts`**: Extended `useSurveyGeoJSON` to accept `"Catastrophe"` as a valid `atName` value; added `useCatastropheGeoJSON` hook.
- **`geoJsonParser.ts`**: Added `transformCatastropheFeatures` function that maps GeoJSON Point features to catastrophe objects, including severity inference (`BLOCKAGE` → high, `BREAK`/`BURST` → critical, `LEAK` → medium).
- **`CatastropheManagement.tsx`**:
  - Replaced the old REST-based catastrophe fetch with `useCatastropheGeoJSON`.
  - Added `mapCatastrophes` memo to parse and transform the GeoJSON response.
  - Added a `useEffect` to sync `mapCatastrophes` into the grid state (`setCatastrophes`).
  - Updated the map `catastrophes` prop to use `mapCatastrophes` directly (with correct `lat`/`lng` and `severity` fields).
  - Made `showCatastrophes` conditional on data availability, preventing errors on other pages where catastrophe data is absent.
  - Updated `handleRefresh` and `isLoading` to use the new GeoJSON-based data source.

---

<a href="https://builder.io/app/projects/1763b41e17984ccbbbee926081ee97f4/teal-grip-odfvgl4t"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://1763b41e17984ccbbbee926081ee97f4-teal-grip-odfvgl4t_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 219`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1763b41e17984ccbbbee926081ee97f4</projectId>-->
<!--<branchName>teal-grip-odfvgl4t</branchName>-->