### PR TITLE
Add catastrophe points and map click support to RGIS map

### DIFF
--- a/src/components/CatastropheManagement.tsx
+++ b/src/components/CatastropheManagement.tsx
@@ -492,10 +492,21 @@ const CatastropheManagement = () => {
                     devices={mapConsumers as any[]}
                     pipelines={mapPipelines}
                     valves={mapValves}
+                    catastrophes={mapCatastrophes.map((c) => ({
+                      id: c.id,
+                      name: c.type,
+                      severity: c.severity,
+                      coordinates: { lat: c.lat, lng: c.lng },
+                      description: c.description,
+                    }))}
                     showDevices={false}
                     showPipelines={mapPipelines.some(p => (p.coordinates?.length ?? 0) >= 2)}
                     showValves={mapValves.some(v => !!v.coordinates)}
                     showConsumers={false}
+                    showCatastrophes={mapCatastrophes.length > 0}
+                    onMapClick={handleMapClick}
+                    selectedLocation={selectedLocation}
+                    disableAutoFit={!!selectedLocation}
                   />
                 ) : (
                   <LeafletMap

--- a/src/components/RGISMap.tsx
+++ b/src/components/RGISMap.tsx
@@ -10,6 +10,15 @@ import "@arcgis/core/assets/esri/themes/light/main.css";
 const DEFAULT_CENTER: [number, number] = [91.7362, 26.1445]; // longitude, latitude
 const DEFAULT_ZOOM = 13;
 
+const getCatastropheColor = (severity?: string): [number, number, number] => {
+  const s = String(severity || "").toLowerCase();
+  if (s.includes("critical")) return [153, 27, 27]; // #991b1b - red-900
+  if (s.includes("high") || s.includes("major")) return [239, 68, 68]; // #ef4444 - red-500
+  if (s.includes("medium") || s.includes("moderate")) return [245, 158, 11]; // #f59e0b - amber-500
+  if (s.includes("low") || s.includes("minor")) return [34, 197, 94]; // #22c55e - green-500
+  return [168, 85, 247]; // #a855f7 - purple-500
+};
+
 const DEFAULT_PIPELINE_ROUTES: [number, number][][] = [
   [
     [-73.9851, 40.7589],
@@ -111,27 +120,45 @@ interface ConsumerPoint {
   coordinates: { lat: number; lng: number };
 }
 
+interface CatastrophePoint {
+  id: string;
+  name?: string;
+  severity?: string;
+  status?: string;
+  coordinates?: { lat: number; lng: number };
+  description?: string;
+}
+
 interface RGISMapProps {
   devices: DeviceLocation[];
   pipelines: PipelineSegment[];
   valves: ValvePoint[];
   consumers?: ConsumerPoint[];
+  catastrophes?: CatastrophePoint[];
   showDevices: boolean;
   showPipelines: boolean;
   showValves: boolean;
-  showConsumers:boolean;
-  
+  showConsumers: boolean;
+  showCatastrophes?: boolean;
+  onMapClick?: (lat: number, lng: number) => void;
+  selectedLocation?: { lat: number; lng: number } | null;
+  disableAutoFit?: boolean;
 }
 
 export const RGISMap = ({
   devices,
   pipelines,
   valves,
-  consumers=[],
+  consumers = [],
+  catastrophes = [],
   showDevices,
   showPipelines,
   showValves,
   showConsumers = false,
+  showCatastrophes = false,
+  onMapClick,
+  selectedLocation,
+  disableAutoFit = false,
 }: RGISMapProps) => {
   const mapRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<MapView | null>(null);
@@ -152,13 +179,23 @@ export const RGISMap = ({
 
     viewRef.current = view;
 
+    // Add click handler
+    if (onMapClick) {
+      view.on("click", (event: any) => {
+        const pt = view.toMap({ x: event.x, y: event.y });
+        if (pt) {
+          onMapClick(pt.latitude, pt.longitude);
+        }
+      });
+    }
+
     return () => {
       if (viewRef.current) {
         viewRef.current.destroy();
         viewRef.current = null;
       }
     };
-  }, []);
+  }, [onMapClick]);
 
   useEffect(() => {
     if (!viewRef.current) return;
@@ -341,14 +378,80 @@ export const RGISMap = ({
       });
     }
 
+    if (showCatastrophes) {
+      (catastrophes || []).forEach((catastrophe) => {
+        if (!catastrophe.coordinates?.lat || !catastrophe.coordinates?.lng) return;
+
+        const pt = new Point({
+          longitude: catastrophe.coordinates.lng,
+          latitude: catastrophe.coordinates.lat,
+        });
+        allPoints.push(pt);
+
+        const color = getCatastropheColor(catastrophe.severity);
+        const markerSymbol = {
+          type: "simple-marker",
+          color: color,
+          size: "10px",
+          outline: {
+            color: [255, 255, 255],
+            width: 1.5,
+          },
+        };
+
+        const graphic = new Graphic({
+          geometry: pt,
+          symbol: markerSymbol as any,
+          attributes: catastrophe,
+          popupTemplate: {
+            title: catastrophe.name ?? `Catastrophe ${catastrophe.id}`,
+            content: `Severity: {severity}<br>Status: {status}<br>Description: {description}`,
+          },
+        });
+
+        graphicsLayer.add(graphic);
+      });
+    }
+
+    // Add selected location marker if present
+    if (selectedLocation && Number.isFinite(selectedLocation.lat) && Number.isFinite(selectedLocation.lng)) {
+      const pt = new Point({
+        longitude: selectedLocation.lng,
+        latitude: selectedLocation.lat,
+      });
+
+      const markerSymbol = {
+        type: "simple-marker",
+        color: [14, 165, 233], // cyan-500 (#0ea5e9)
+        size: "10px",
+        outline: {
+          color: [255, 255, 255],
+          width: 2,
+        },
+      };
+
+      const graphic = new Graphic({
+        geometry: pt,
+        symbol: markerSymbol as any,
+        attributes: { name: "Selected Location" },
+        popupTemplate: {
+          title: "Selected Location",
+          content: `Latitude: ${selectedLocation.lat.toFixed(4)}<br>Longitude: ${selectedLocation.lng.toFixed(4)}`,
+        },
+      });
+
+      graphicsLayer.add(graphic);
+      allPoints.push(pt);
+    }
+
     // Zoom to fit all graphics
-    if (allPoints.length > 0) {
+    if (allPoints.length > 0 && !disableAutoFit && !selectedLocation) {
         view.when(() => {
             view.goTo(graphicsLayer.graphics);
         });
     }
 
-  }, [devices, pipelines, valves, consumers, showDevices, showPipelines, showValves, showConsumers]);
+  }, [devices, pipelines, valves, consumers, catastrophes, showDevices, showPipelines, showValves, showConsumers, showCatastrophes, selectedLocation, disableAutoFit]);
 
   return (
     <div className="w-full h-full relative">


### PR DESCRIPTION
### Summary
This PR brings the RGIS (ArcGIS) map in `CatastropheManagement` to feature parity with the Leaflet map by adding catastrophe point rendering and interactive map-click location selection.

### Problem
The RGIS map in the `CatastropheManagement` page lacked the ability to display existing catastrophe points and did not support clicking on the map to set a location when creating a new catastrophe — functionality that was already available in the Leaflet map implementation.

### Solution
Extended `RGISMap` with new props for catastrophe data, map click handling, and selected location display. Updated `CatastropheManagement` to pass the relevant data and handlers to the RGIS map, mirroring the existing Leaflet map integration.

### Key Changes
- **`RGISMap.tsx`**:
  - Added `CatastrophePoint` interface and new props: `catastrophes`, `showCatastrophes`, `onMapClick`, `selectedLocation`, and `disableAutoFit`
  - Added `getCatastropheColor()` helper to map severity levels (`critical`, `high/major`, `medium/moderate`, `low/minor`) to distinct colors
  - Renders catastrophe markers on the ArcGIS graphics layer with severity-based colors and popup templates
  - Wires up a `view.on("click")` handler to invoke `onMapClick` with the clicked map coordinates
  - Renders a cyan "Selected Location" marker when `selectedLocation` is set
  - Skips auto-fit zoom when `disableAutoFit` is true or a selected location is active
- **`CatastropheManagement.tsx`**:
  - Passes `catastrophes`, `showCatastrophes`, `onMapClick`, `selectedLocation`, and `disableAutoFit` props to `RGISMap`, matching the Leaflet map's behavior


---

<a href="https://builder.io/app/projects/1763b41e17984ccbbbee926081ee97f4/royal-tooth-d89fpnxh"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://1763b41e17984ccbbbee926081ee97f4-royal-tooth-d89fpnxh_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 220`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1763b41e17984ccbbbee926081ee97f4</projectId>-->
<!--<branchName>royal-tooth-d89fpnxh</branchName>-->