### PR TITLE
Send address field data through save API

### DIFF
--- a/src/components/CatastropheManagement.tsx
+++ b/src/components/CatastropheManagement.tsx
@@ -205,6 +205,7 @@ const CatastropheManagement = () => {
             pipelineId: catastropheData.segmentId,
             reportedDate: new Date(catastropheData.reportedDate),
             location: catastropheData.location.lat + "," + catastropheData.location.lng,
+            address: catastropheData.location.address,
             segment: catastropheData.segmentId,
           },
         });
@@ -213,6 +214,7 @@ const CatastropheManagement = () => {
         await createCatastropheMutation.mutateAsync({
           type: catastropheData.type.toUpperCase().replace("-", "_") as any,
           location: catastropheData.location.lat + "," + catastropheData.location.lng,
+          address: catastropheData.location.address,
           coordinates: {
             lat: catastropheData.location.lat,
             lng: catastropheData.location.lng,


### PR DESCRIPTION
### Summary
This PR ensures the address field from the location data is included when saving a catastrophe, passing it through both the update and create API calls.

### Problem
When clicking the Save button in Catastrophe Management, the address field from the location object was not being sent to the save API. This meant address data was silently dropped and never persisted.

### Solution
Added `address: catastropheData.location.address` to the payload in both the update (mutation) and create (`createCatastropheMutation`) API calls so the address is correctly included on save.

### Key Changes
- Included `address` field from `catastropheData.location.address` in the update mutation payload
- Included `address` field from `catastropheData.location.address` in the create mutation payload


---

<a href="https://builder.io/app/projects/fafa5a82811f47968513a2866280018e/cinder-portal-sea8i4ip"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://fafa5a82811f47968513a2866280018e-cinder-portal-sea8i4ip_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 222`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fafa5a82811f47968513a2866280018e</projectId>-->
<!--<branchName>cinder-portal-sea8i4ip</branchName>-->