### PR TITLE
Show consumers on map point click in ConsumerPointsEditor

### DIFF
--- a/src/components/ConsumerPointsEditor.tsx
+++ b/src/components/ConsumerPointsEditor.tsx
@@ -15,7 +15,14 @@ import {
 import { SortableTableHead } from "@/components/ui/sortable-table-head";
 import { Pagination } from "@/components/ui/pagination";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { MapPin, AlertTriangle, Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { MapPin, AlertTriangle, Loader2, X } from "lucide-react";
 import { useTable } from "@/hooks/use-table";
 import { useDeviceLogs } from "@/hooks/useApiQueries";
 import { apiClient } from "@/lib/api";
@@ -38,6 +45,33 @@ export const ConsumerPointsEditor = () => {
   const [columns, setColumns] = useState<string[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const [selectedPoint, setSelectedPoint] = useState<{ lat: number; lng: number } | null>(null);
+  const [pointConsumers, setPointConsumers] = useState<DynamicRow[]>([]);
+  const [loadingConsumers, setLoadingConsumers] = useState(false);
+  const [consumerModalOpen, setConsumerModalOpen] = useState(false);
+
+  // Handle map point click to show consumers at that point
+  const handleMapPointClick = (lat: number, lng: number) => {
+    setSelectedPoint({ lat, lng });
+    setLoadingConsumers(true);
+
+    // Filter consumers at the clicked point (with small tolerance for floating point)
+    const tolerance = 0.0001; // ~10 meters at equator
+    const consumersAtPoint = rows.filter(
+      (row) => {
+        const rowLat = Number(row.lat || row.CONSUMER_LAT || 0);
+        const rowLng = Number(row.lng || row.CONSUMER_LNG || 0);
+        return (
+          Math.abs(rowLat - lat) < tolerance &&
+          Math.abs(rowLng - lng) < tolerance
+        );
+      }
+    );
+
+    setPointConsumers(consumersAtPoint);
+    setLoadingConsumers(false);
+    setConsumerModalOpen(true);
+  };
 
   // Load consumers from survey-geojson endpoint
   useEffect(() => {
@@ -160,6 +194,7 @@ export const ConsumerPointsEditor = () => {
                   showPipelines={false}
                   showValves={false}
                   showConsumers={mapConsumers.length > 0}
+                  onMapClick={handleMapPointClick}
                 />
               ) : (
                 <LeafletMap
@@ -171,6 +206,7 @@ export const ConsumerPointsEditor = () => {
                   showPipelines={false}
                   showValves={false}
                   showConsumers={mapConsumers.length > 0}
+                  onMapClick={handleMapPointClick}
                 />
               )}
             </div>
@@ -252,6 +288,58 @@ export const ConsumerPointsEditor = () => {
           </CardContent>
         </Card>
       </div>
+
+      {/* Consumer Modal Dialog */}
+      <Dialog open={consumerModalOpen} onOpenChange={setConsumerModalOpen}>
+        <DialogContent className="max-w-4xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <MapPin className="h-5 w-5" />
+              Consumers at Point ({selectedPoint?.lat.toFixed(4)}, {selectedPoint?.lng.toFixed(4)})
+            </DialogTitle>
+            <DialogClose />
+          </DialogHeader>
+
+          {loadingConsumers ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-8 w-8 animate-spin" />
+              <span className="ml-2 text-sm text-muted-foreground">Loading consumers...</span>
+            </div>
+          ) : pointConsumers.length === 0 ? (
+            <Alert>
+              <AlertDescription>No consumers found at this location.</AlertDescription>
+            </Alert>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    {Object.keys(pointConsumers[0] || {}).map((col) => (
+                      <TableHead key={col} className="whitespace-nowrap">
+                        {col}
+                      </TableHead>
+                    ))}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {pointConsumers.map((consumer, idx) => (
+                    <TableRow key={String(consumer.id ?? idx)}>
+                      {Object.keys(consumer).map((col) => {
+                        const value = consumer[col];
+                        return (
+                          <TableCell key={col} className="whitespace-nowrap">
+                            {value === null || value === undefined || value === "" ? "-" : String(value)}
+                          </TableCell>
+                        );
+                      })}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };


### PR DESCRIPTION
### Summary
Adds an interactive modal dialog in the `ConsumerPointsEditor` page that displays all consumers belonging to a specific map point when it is clicked.

### Problem
Previously, clicking a consumer point on the map had no interaction — users had no way to view which consumers were associated with a particular geographic location directly from the map view.

### Solution
A click handler is wired to the map component that filters the already-loaded consumer data by geographic coordinates (with a small floating-point tolerance) and displays the matching consumers in a modal dialog table.

### Key Changes
- Added `handleMapPointClick` handler that filters `rows` by latitude/longitude with a `0.0001` degree tolerance (~10 meters) to find consumers at the clicked point
- Introduced new state variables: `selectedPoint`, `pointConsumers`, `loadingConsumers`, and `consumerModalOpen` to manage the modal lifecycle
- Passed `onMapClick={handleMapPointClick}` to both map component variants (conditional render paths)
- Added a `Dialog` modal that renders a dynamic table of all consumer fields for the matched consumers at the clicked point, with loading and empty-state handling
- Imported and used `Dialog`, `DialogContent`, `DialogHeader`, `DialogTitle`, `DialogClose` from the UI library, and the `X` icon from `lucide-react`


---

<a href="https://builder.io/app/projects/fafa5a82811f47968513a2866280018e/linear-border-yhgtqdft"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://fafa5a82811f47968513a2866280018e-linear-border-yhgtqdft_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 223`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fafa5a82811f47968513a2866280018e</projectId>-->
<!--<branchName>linear-border-yhgtqdft</branchName>-->