### PR TITLE
Show only consumer fields in map point modal

### DIFF
--- a/src/components/ConsumerPointsEditor.tsx
+++ b/src/components/ConsumerPointsEditor.tsx
@@ -291,7 +291,7 @@ export const ConsumerPointsEditor = () => {
 
       {/* Consumer Modal Dialog */}
       <Dialog open={consumerModalOpen} onOpenChange={setConsumerModalOpen}>
-        <DialogContent className="max-w-4xl max-h-[80vh] overflow-y-auto">
+        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <MapPin className="h-5 w-5" />
@@ -314,24 +314,27 @@ export const ConsumerPointsEditor = () => {
               <Table>
                 <TableHeader>
                   <TableRow>
-                    {Object.keys(pointConsumers[0] || {}).map((col) => (
-                      <TableHead key={col} className="whitespace-nowrap">
-                        {col}
-                      </TableHead>
-                    ))}
+                    <TableHead className="whitespace-nowrap">Name</TableHead>
+                    <TableHead className="whitespace-nowrap">Code</TableHead>
+                    <TableHead className="whitespace-nowrap">Mobile</TableHead>
+                    <TableHead className="whitespace-nowrap">Point</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {pointConsumers.map((consumer, idx) => (
                     <TableRow key={String(consumer.id ?? idx)}>
-                      {Object.keys(consumer).map((col) => {
-                        const value = consumer[col];
-                        return (
-                          <TableCell key={col} className="whitespace-nowrap">
-                            {value === null || value === undefined || value === "" ? "-" : String(value)}
-                          </TableCell>
-                        );
-                      })}
+                      <TableCell className="whitespace-nowrap">
+                        {consumer.Consumer_Name ? String(consumer.Consumer_Name) : "-"}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        {consumer.Consumer_Code ? String(consumer.Consumer_Code) : "-"}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        {consumer.Mobile ? String(consumer.Mobile) : "-"}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        {consumer.SE_VALUE ? String(consumer.SE_VALUE) : "-"}
+                      </TableCell>
                     </TableRow>
                   ))}
                 </TableBody>


### PR DESCRIPTION
### Summary
Updates the consumer modal dialog on the `ConsumerPointsEditor` map to display only relevant consumer fields (Name, Code, Mobile, Point) instead of dynamically rendering all object keys.

### Problem
When clicking a point on the map in the `ConsumerPointsEditor` page, the consumer modal grid was dynamically rendering all keys from the consumer object, which caused raw object references to appear in the "Consumer" column and displayed many irrelevant columns.

### Solution
Replaced the dynamic column rendering with a fixed set of explicitly defined columns — Name, Code, Mobile, and Point — mapped to their corresponding consumer data fields.

### Key Changes
- Replaced dynamic `Object.keys()` column generation with four explicit `TableHead` columns: **Name**, **Code**, **Mobile**, and **Point**
- Replaced dynamic `Object.keys()` cell rendering with explicit `TableCell` entries for `Consumer_Name`, `Consumer_Code`, `Mobile`, and `SE_VALUE`
- Narrowed the modal dialog width from `max-w-4xl` to `max-w-2xl` to better fit the reduced column count


---

<a href="https://builder.io/app/projects/fafa5a82811f47968513a2866280018e/warrior-library-ne8h1vul"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://fafa5a82811f47968513a2866280018e-warrior-library-ne8h1vul_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 224`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fafa5a82811f47968513a2866280018e</projectId>-->
<!--<branchName>warrior-library-ne8h1vul</branchName>-->