### PR TITLE
Add file type selection for export (KML or XLSX)

### DIFF
--- a/src/components/ExportImport.tsx
+++ b/src/components/ExportImport.tsx
@@ -13,6 +13,7 @@ export default function ExportImport() {
   const [assetTypes, setAssetTypes] = useState<AssetType[]>([]);
   const [selectedAssetTypeId, setSelectedAssetTypeId] = useState<string>("");
   const [selectedAssetType, setSelectedAssetType] = useState<AssetType | null>(null);
+  const [fileType, setFileType] = useState<"kml" | "xlsx">("kml");
   const [isLoading, setIsLoading] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
@@ -43,15 +44,36 @@ export default function ExportImport() {
     setMessage(null);
   };
 
+  const getDownloadFilename = (): string => {
+    if (!selectedAssetType) return "";
+
+    const assetName = selectedAssetType.name.toLowerCase();
+    let baseFileName = "";
+
+    if (assetName === "customer data points") {
+      baseFileName = "customerdatapoints";
+    } else if (assetName === "pipeline") {
+      baseFileName = "pipeline";
+    } else if (assetName === "valve") {
+      baseFileName = "valve";
+    } else {
+      baseFileName = assetName.replace(/\s+/g, "");
+    }
+
+    return `${baseFileName}.${fileType}`;
+  };
+
   const handleExport = async () => {
     if (!selectedAssetType) return;
+
+    const filename = getDownloadFilename();
+    if (!filename) return;
 
     setIsExporting(true);
     setMessage(null);
     try {
-      // API endpoint call for export with selected asset type ID
       const response = await fetch(
-        `https://localhost:7215/api/AssetTypes/export?assetTypeId=${selectedAssetType.id}`,
+        `https://localhost:7215/api/SurveyEntries/download?filename=${encodeURIComponent(filename)}`,
         {
           method: "GET",
           headers: {
@@ -64,42 +86,23 @@ export default function ExportImport() {
         throw new Error(`Export failed with status ${response.status}`);
       }
 
-      // Handle the response (could be JSON or file download)
-      const contentType = response.headers.get("content-type");
-      if (contentType && contentType.includes("application/json")) {
-        const data = await response.json();
-        // Trigger download if data contains file information
-        const blob = new Blob([JSON.stringify(data, null, 2)], {
-          type: "application/json",
-        });
-        const url = window.URL.createObjectURL(blob);
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = `export-${selectedAssetType.name}-${Date.now()}.json`;
-        document.body.appendChild(a);
-        a.click();
-        window.URL.revokeObjectURL(url);
-        document.body.removeChild(a);
-      } else {
-        // Handle file download directly
-        const blob = await response.blob();
-        const url = window.URL.createObjectURL(blob);
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = `export-${selectedAssetType.name}-${Date.now()}`;
-        document.body.appendChild(a);
-        a.click();
-        window.URL.revokeObjectURL(url);
-        document.body.removeChild(a);
-      }
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
 
       setMessage({
         type: "success",
-        text: `Successfully exported ${selectedAssetType.name} data`,
+        text: `Successfully exported ${selectedAssetType.name} data as ${fileType.toUpperCase()}`,
       });
       toast({
         title: "Export Successful",
-        description: `${selectedAssetType.name} data has been exported`,
+        description: `${selectedAssetType.name} data has been exported as ${fileType.toUpperCase()}`,
       });
     } catch (error) {
       console.error("Error exporting data:", error);
@@ -233,6 +236,25 @@ export default function ExportImport() {
                 </SelectContent>
               </Select>
             </div>
+
+            {/* File Type Selector for Export */}
+            {selectedAssetType && (
+              <div className="space-y-2">
+                <Label htmlFor="file-type-select">Export File Type</Label>
+                <Select
+                  value={fileType}
+                  onValueChange={(value) => setFileType(value as "kml" | "xlsx")}
+                >
+                  <SelectTrigger id="file-type-select" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="kml">KML File (.kml)</SelectItem>
+                    <SelectItem value="xlsx">Excel File (.xlsx)</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
 
             {/* Selected Asset Type Info */}
             {selectedAssetType && (


### PR DESCRIPTION
### Summary
Adds a file type selector (KML or XLSX) to the Export/Import component, allowing users to choose their preferred download format before exporting asset data.

### Problem
The export functionality previously used a hardcoded endpoint and generic filename without giving users control over the output file format. There was no way to select between KML and Excel (XLSX) formats, and the download API endpoint was incorrect.

### Solution
Introduced a file type state (`kml` | `xlsx`) and a dynamic filename generator that maps asset types to their correct filenames. The export now calls the correct `/api/SurveyEntries/download?filename=` endpoint with the appropriate filename based on both the selected asset type and chosen file format.

### Key Changes
- Added `fileType` state (`"kml" | "xlsx"`, defaulting to `"kml"`) to track the user's selected export format
- Added `getDownloadFilename()` helper that maps asset type names (e.g., "customer data points", "pipeline", "valve") to their corresponding filenames with the correct extension
- Updated `handleExport` to use the new `/api/SurveyEntries/download?filename=` endpoint with the dynamically generated filename
- Simplified the download logic to a single blob-based file download flow, removing the previous content-type branching
- Added a **Export File Type** `<Select>` dropdown (KML / Excel) that appears after an asset type is selected
- Updated success messages and toast notifications to include the selected file format

---

<a href="https://builder.io/app/projects/fafa5a82811f47968513a2866280018e/navy-riddle-2prgicbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://fafa5a82811f47968513a2866280018e-navy-riddle-2prgicbf_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 228`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fafa5a82811f47968513a2866280018e</projectId>-->
<!--<branchName>navy-riddle-2prgicbf</branchName>-->