### PR TITLE
Replace export file type dropdown with export split button

### DIFF
--- a/src/components/ExportImport.tsx
+++ b/src/components/ExportImport.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Download, Upload } from "lucide-react";
+import { Download, Upload, ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -8,12 +8,17 @@ import { apiClient, type AssetType } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertTriangle, CheckCircle } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 export default function ExportImport() {
   const [assetTypes, setAssetTypes] = useState<AssetType[]>([]);
   const [selectedAssetTypeId, setSelectedAssetTypeId] = useState<string>("");
   const [selectedAssetType, setSelectedAssetType] = useState<AssetType | null>(null);
-  const [fileType, setFileType] = useState<"kml" | "xlsx">("kml");
   const [isLoading, setIsLoading] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
@@ -60,13 +65,13 @@ export default function ExportImport() {
       baseFileName = assetName.replace(/\s+/g, "");
     }
 
-    return `${baseFileName}.${fileType}`;
+    return baseFileName;
   };
 
-  const handleExport = async () => {
+  const handleExport = async (format: "kml" | "xlsx") => {
     if (!selectedAssetType) return;
 
-    const filename = getDownloadFilename();
+    const filename = `${getDownloadFilename().split(".")[0]}.${format}`;
     if (!filename) return;
 
     setIsExporting(true);
@@ -98,11 +103,11 @@ export default function ExportImport() {
 
       setMessage({
         type: "success",
-        text: `Successfully exported ${selectedAssetType.name} data as ${fileType.toUpperCase()}`,
+        text: `Successfully exported ${selectedAssetType.name} data as ${format.toUpperCase()}`,
       });
       toast({
         title: "Export Successful",
-        description: `${selectedAssetType.name} data has been exported as ${fileType.toUpperCase()}`,
+        description: `${selectedAssetType.name} data has been exported as ${format.toUpperCase()}`,
       });
     } catch (error) {
       console.error("Error exporting data:", error);
@@ -237,24 +242,6 @@ export default function ExportImport() {
               </Select>
             </div>
 
-            {/* File Type Selector for Export */}
-            {selectedAssetType && (
-              <div className="space-y-2">
-                <Label htmlFor="file-type-select">Export File Type</Label>
-                <Select
-                  value={fileType}
-                  onValueChange={(value) => setFileType(value as "kml" | "xlsx")}
-                >
-                  <SelectTrigger id="file-type-select" className="w-full">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="kml">KML File (.kml)</SelectItem>
-                    <SelectItem value="xlsx">Excel File (.xlsx)</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
 
             {/* Selected Asset Type Info */}
             {selectedAssetType && (
@@ -290,15 +277,27 @@ export default function ExportImport() {
 
             {/* Export and Import Buttons */}
             <div className="flex gap-4 pt-4">
-              <Button
-                onClick={handleExport}
-                disabled={!selectedAssetType || isExporting}
-                className="flex-1"
-                variant="default"
-              >
-                <Download className="mr-2 h-4 w-4" />
-                {isExporting ? "Exporting..." : "Export Data"}
-              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    disabled={!selectedAssetType || isExporting}
+                    className="flex-1"
+                    variant="default"
+                  >
+                    <Download className="mr-2 h-4 w-4" />
+                    {isExporting ? "Exporting..." : "Export"}
+                    <ChevronDown className="ml-2 h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="w-48">
+                  <DropdownMenuItem onClick={() => handleExport("kml")}>
+                    Export KML
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => handleExport("xlsx")}>
+                    Export XLSX
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
               <Button
                 onClick={handleImport}
                 disabled={!selectedAssetType || isImporting}


### PR DESCRIPTION
### Summary
Replaces the separate file type selection dropdown on the Export/Import page with a single Export button that contains a dropdown menu offering "Export KML" and "Export XLSX" options directly.

### Problem
The Export/Import page previously required users to first select a file type from a separate dropdown and then click the Export button — an unnecessary two-step interaction that cluttered the UI.

### Solution
Removed the standalone file type `<Select>` component and the `fileType` state. The Export button is now a `DropdownMenu` trigger that presents format options ("Export KML" and "Export XLSX") inline, passing the chosen format directly to `handleExport`.

### Key Changes
- Removed the `fileType` state variable and the "Export File Type" `<Select>` dropdown from the UI.
- Replaced the plain Export `<Button>` with a `DropdownMenu` component using `DropdownMenuTrigger`, `DropdownMenuContent`, and `DropdownMenuItem`.
- Updated `handleExport` to accept a `format: "kml" | "xlsx"` parameter instead of reading from state.
- Added `ChevronDown` icon to the Export button to indicate the dropdown affordance.
- Updated success messages and toast notifications to use the `format` parameter passed at call time.


---

<a href="https://builder.io/app/projects/fafa5a82811f47968513a2866280018e/maroon-meteor-ns3ir08u"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://fafa5a82811f47968513a2866280018e-maroon-meteor-ns3ir08u_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 229`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fafa5a82811f47968513a2866280018e</projectId>-->
<!--<branchName>maroon-meteor-ns3ir08u</branchName>-->