### PR TITLE
Add activate/deactivate Action column to survey entry grids

### DIFF
--- a/src/components/CatastropheList.tsx
+++ b/src/components/CatastropheList.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -12,7 +13,9 @@ import { SortableTableHead } from "@/components/ui/sortable-table-head";
 import { Pagination } from "@/components/ui/pagination";
 import { useTable } from "@/hooks/use-table";
 import { Badge } from "@/components/ui/badge";
-import { Edit, MapPin, Calendar } from "lucide-react";
+import { Edit, MapPin, Calendar, Loader2 } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { API_BASE_PATH } from "@/lib/api";
 import { Catastrophe } from "./CatastropheManagement";
 
 interface CatastropheListProps {
@@ -52,6 +55,10 @@ export const CatastropheList = ({
   catastrophes,
   onEdit,
 }: CatastropheListProps) => {
+  const { toast } = useToast();
+  const [deactivatedItems, setDeactivatedItems] = useState<Set<string>>(new Set());
+  const [loadingIds, setLoadingIds] = useState<Set<string>>(new Set());
+
   const formatDate = (date: Date | null | undefined) => {
     if (!date) return "-";
     return new Intl.DateTimeFormat("en-US", {
@@ -59,6 +66,44 @@ export const CatastropheList = ({
       month: "short",
       day: "numeric",
     }).format(date);
+  };
+
+  const handleToggleDeactivate = async (id: string) => {
+    setLoadingIds((prev) => new Set(prev).add(id));
+    try {
+      const url = `${API_BASE_PATH}/SurveyEntries/deactivate-survey-entry?seId=${encodeURIComponent(id)}`;
+      const response = await fetch(url, { method: "POST" });
+      if (!response.ok) {
+        throw new Error(`Failed to deactivate entry: ${response.status}`);
+      }
+      setDeactivatedItems((prev) => {
+        const newSet = new Set(prev);
+        if (newSet.has(id)) {
+          newSet.delete(id);
+        } else {
+          newSet.add(id);
+        }
+        return newSet;
+      });
+      const isDeactivating = !deactivatedItems.has(id);
+      toast({
+        title: isDeactivating ? "Deactivated" : "Activated",
+        description: `Catastrophe entry ${isDeactivating ? "deactivated" : "activated"} successfully`,
+      });
+    } catch (error) {
+      console.error("Error toggling deactivation:", error);
+      toast({
+        title: "Error",
+        description: "Failed to update entry status",
+        variant: "destructive",
+      });
+    } finally {
+      setLoadingIds((prev) => {
+        const newSet = new Set(prev);
+        newSet.delete(id);
+        return newSet;
+      });
+    }
   };
 
   // Use the table hook for sorting and pagination
@@ -133,7 +178,10 @@ export const CatastropheList = ({
                       Reported Date
                     </SortableTableHead>
                     <SortableTableHead sortable={false} className="text-right">
-                      Actions
+                      Action
+                    </SortableTableHead>
+                    <SortableTableHead sortable={false} className="text-right">
+                      Edit
                     </SortableTableHead>
                   </TableRow>
                 </TableHeader>
@@ -186,6 +234,20 @@ export const CatastropheList = ({
                           <Calendar className="h-3 w-3 text-muted-foreground" />
                           {formatDate(catastrophe.reportedDate)}
                         </div>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          variant={deactivatedItems.has(catastrophe.id) ? "outline" : "default"}
+                          size="sm"
+                          onClick={() => handleToggleDeactivate(catastrophe.id)}
+                          disabled={loadingIds.has(catastrophe.id)}
+                          className="gap-1"
+                        >
+                          {loadingIds.has(catastrophe.id) && (
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                          )}
+                          {deactivatedItems.has(catastrophe.id) ? "Activate" : "Deactivate"}
+                        </Button>
                       </TableCell>
                       <TableCell className="text-right">
                         <Button

--- a/src/components/CatastropheList.tsx
+++ b/src/components/CatastropheList.tsx
@@ -13,7 +13,7 @@ import { SortableTableHead } from "@/components/ui/sortable-table-head";
 import { Pagination } from "@/components/ui/pagination";
 import { useTable } from "@/hooks/use-table";
 import { Badge } from "@/components/ui/badge";
-import { Edit, MapPin, Calendar, Loader2 } from "lucide-react";
+import { Edit, MapPin, Calendar, Loader2, Power } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { API_BASE_PATH } from "@/lib/api";
 import { Catastrophe } from "./CatastropheManagement";
@@ -177,6 +177,9 @@ export const CatastropheList = ({
                     >
                       Reported Date
                     </SortableTableHead>
+                    <SortableTableHead sortable={false}>
+                      Status
+                    </SortableTableHead>
                     <SortableTableHead sortable={false} className="text-right">
                       Action
                     </SortableTableHead>
@@ -235,9 +238,14 @@ export const CatastropheList = ({
                           {formatDate(catastrophe.reportedDate)}
                         </div>
                       </TableCell>
+                      <TableCell>
+                        <Badge variant={deactivatedItems.has(catastrophe.id) ? "outline" : "secondary"}>
+                          {deactivatedItems.has(catastrophe.id) ? "Inactive" : "Active"}
+                        </Badge>
+                      </TableCell>
                       <TableCell className="text-right">
                         <Button
-                          variant={deactivatedItems.has(catastrophe.id) ? "outline" : "default"}
+                          variant="ghost"
                           size="sm"
                           onClick={() => handleToggleDeactivate(catastrophe.id)}
                           disabled={loadingIds.has(catastrophe.id)}
@@ -246,7 +254,7 @@ export const CatastropheList = ({
                           {loadingIds.has(catastrophe.id) && (
                             <Loader2 className="h-3 w-3 animate-spin" />
                           )}
-                          {deactivatedItems.has(catastrophe.id) ? "Activate" : "Deactivate"}
+                          <Power className="h-3 w-3" />
                         </Button>
                       </TableCell>
                       <TableCell className="text-right">

--- a/src/components/PipelineNetworkEditor.tsx
+++ b/src/components/PipelineNetworkEditor.tsx
@@ -41,6 +41,7 @@ import {
   MapPin,
   AlertTriangle,
   Loader2,
+  Power,
 } from "lucide-react";
 
 import { useToast } from "@/hooks/use-toast";
@@ -575,6 +576,9 @@ export const PipelineNetworkEditor = () => {
                               {col}
                             </SortableTableHead>
                           ))}
+                          <SortableTableHead sortable={false}>
+                            Status
+                          </SortableTableHead>
                           <SortableTableHead sortable={false} className="text-right">
                             Action
                           </SortableTableHead>
@@ -595,9 +599,14 @@ export const PipelineNetworkEditor = () => {
                               </TableCell>
                             );
                           })}
+                          <TableCell>
+                            <Badge variant={deactivatedPipelineIds.has(seId) ? "outline" : "secondary"}>
+                              {deactivatedPipelineIds.has(seId) ? "Inactive" : "Active"}
+                            </Badge>
+                          </TableCell>
                           <TableCell className="text-right">
                             <Button
-                              variant={deactivatedPipelineIds.has(seId) ? "outline" : "default"}
+                              variant="ghost"
                               size="sm"
                               onClick={() => handleTogglePipelineDeactivate(seId)}
                               disabled={loadingPipelineIds.has(seId)}
@@ -606,7 +615,7 @@ export const PipelineNetworkEditor = () => {
                               {loadingPipelineIds.has(seId) && (
                                 <Loader2 className="h-3 w-3 animate-spin" />
                               )}
-                              {deactivatedPipelineIds.has(seId) ? "Activate" : "Deactivate"}
+                              <Power className="h-3 w-3" />
                             </Button>
                           </TableCell>
                         </TableRow>

--- a/src/components/PipelineNetworkEditor.tsx
+++ b/src/components/PipelineNetworkEditor.tsx
@@ -75,6 +75,8 @@ export const PipelineNetworkEditor = () => {
   const [propColumns, setPropColumns] = useState<string[]>([]);
   const [propLoading, setPropLoading] = useState<boolean>(false);
   const [propError, setPropError] = useState<string | null>(null);
+  const [deactivatedPipelineIds, setDeactivatedPipelineIds] = useState<Set<string>>(new Set());
+  const [loadingPipelineIds, setLoadingPipelineIds] = useState<Set<string>>(new Set());
 
   const [valveRows, setValveRows] = useState<DynamicRow[]>([]);
   const [valveError, setValveError] = useState<string | null>(null);
@@ -406,6 +408,44 @@ export const PipelineNetworkEditor = () => {
     toast({ title: "Geo-data upload feature coming soon" });
   };
 
+  const handleTogglePipelineDeactivate = async (seId: string) => {
+    setLoadingPipelineIds((prev) => new Set(prev).add(seId));
+    try {
+      const url = `${API_BASE_PATH}/SurveyEntries/deactivate-survey-entry?seId=${encodeURIComponent(seId)}`;
+      const response = await fetch(url, { method: "POST" });
+      if (!response.ok) {
+        throw new Error(`Failed to deactivate entry: ${response.status}`);
+      }
+      setDeactivatedPipelineIds((prev) => {
+        const newSet = new Set(prev);
+        if (newSet.has(seId)) {
+          newSet.delete(seId);
+        } else {
+          newSet.add(seId);
+        }
+        return newSet;
+      });
+      const isDeactivating = !deactivatedPipelineIds.has(seId);
+      toast({
+        title: isDeactivating ? "Deactivated" : "Activated",
+        description: `Pipeline entry ${isDeactivating ? "deactivated" : "activated"} successfully`,
+      });
+    } catch (error) {
+      console.error("Error toggling deactivation:", error);
+      toast({
+        title: "Error",
+        description: "Failed to update entry status",
+        variant: "destructive",
+      });
+    } finally {
+      setLoadingPipelineIds((prev) => {
+        const newSet = new Set(prev);
+        newSet.delete(seId);
+        return newSet;
+      });
+    }
+  };
+
   // Use the table hook for sorting and pagination
   const defaultSortKey = (propColumns.includes("id") ? "id" : propColumns[0]) as keyof DynamicRow | undefined;
   const { tableConfig, sortedAndPaginatedData } = useTable<DynamicRow>(propRows, 5, defaultSortKey as any);
@@ -523,33 +563,55 @@ export const PipelineNetworkEditor = () => {
                       {propColumns.length === 0 ? (
                         <TableHead>No data</TableHead>
                       ) : (
-                        propColumns.map((col) => (
-                          <SortableTableHead
-                            key={col}
-                            sortKey={col}
-                            currentSortKey={tableConfig.sortConfig.key as unknown as string}
-                            sortDirection={tableConfig.sortConfig.direction}
-                            onSort={(k) => tableConfig.handleSort(k as keyof DynamicRow)}
-                          >
-                            {col}
+                        <>
+                          {propColumns.map((col) => (
+                            <SortableTableHead
+                              key={col}
+                              sortKey={col}
+                              currentSortKey={tableConfig.sortConfig.key as unknown as string}
+                              sortDirection={tableConfig.sortConfig.direction}
+                              onSort={(k) => tableConfig.handleSort(k as keyof DynamicRow)}
+                            >
+                              {col}
+                            </SortableTableHead>
+                          ))}
+                          <SortableTableHead sortable={false} className="text-right">
+                            Action
                           </SortableTableHead>
-                        ))
+                        </>
                       )}
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {sortedAndPaginatedData.map((row, idx) => (
-                      <TableRow key={String((row as any).id ?? idx)}>
-                        {propColumns.map((col) => {
-                          const value = (row as any)[col];
-                          return (
-                            <TableCell key={col}>
-                              {value === null || value === undefined || value === "" ? "-" : String(value)}
-                            </TableCell>
-                          );
-                        })}
-                      </TableRow>
-                    ))}
+                    {sortedAndPaginatedData.map((row, idx) => {
+                      const seId = String((row as any).SE_ID ?? (row as any).id ?? idx);
+                      return (
+                        <TableRow key={seId}>
+                          {propColumns.map((col) => {
+                            const value = (row as any)[col];
+                            return (
+                              <TableCell key={col}>
+                                {value === null || value === undefined || value === "" ? "-" : String(value)}
+                              </TableCell>
+                            );
+                          })}
+                          <TableCell className="text-right">
+                            <Button
+                              variant={deactivatedPipelineIds.has(seId) ? "outline" : "default"}
+                              size="sm"
+                              onClick={() => handleTogglePipelineDeactivate(seId)}
+                              disabled={loadingPipelineIds.has(seId)}
+                              className="gap-1"
+                            >
+                              {loadingPipelineIds.has(seId) && (
+                                <Loader2 className="h-3 w-3 animate-spin" />
+                              )}
+                              {deactivatedPipelineIds.has(seId) ? "Activate" : "Deactivate"}
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
                   </TableBody>
                 </Table>
               )}

--- a/src/components/ValvePointsEditor.tsx
+++ b/src/components/ValvePointsEditor.tsx
@@ -16,7 +16,8 @@ import {
 import { SortableTableHead } from "@/components/ui/sortable-table-head";
 import { Pagination } from "@/components/ui/pagination";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { MapPin, AlertTriangle, Loader2 } from "lucide-react";
+import { MapPin, AlertTriangle, Loader2, Power } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { useTable } from "@/hooks/use-table";
 import { useDeviceLogs } from "@/hooks/useApiQueries";
 import { useToast } from "@/hooks/use-toast";
@@ -329,6 +330,9 @@ export const ValvePointsEditor = () => {
                               {col}
                             </SortableTableHead>
                           ))}
+                          <SortableTableHead sortable={false}>
+                            Status
+                          </SortableTableHead>
                           <SortableTableHead sortable={false} className="text-right">
                             Action
                           </SortableTableHead>
@@ -349,9 +353,14 @@ export const ValvePointsEditor = () => {
                               </TableCell>
                             );
                           })}
+                          <TableCell>
+                            <Badge variant={deactivatedValveIds.has(seId) ? "outline" : "secondary"}>
+                              {deactivatedValveIds.has(seId) ? "Inactive" : "Active"}
+                            </Badge>
+                          </TableCell>
                           <TableCell className="text-right">
                             <Button
-                              variant={deactivatedValveIds.has(seId) ? "outline" : "default"}
+                              variant="ghost"
                               size="sm"
                               onClick={() => handleToggleValveDeactivate(seId)}
                               disabled={loadingValveIds.has(seId)}
@@ -360,7 +369,7 @@ export const ValvePointsEditor = () => {
                               {loadingValveIds.has(seId) && (
                                 <Loader2 className="h-3 w-3 animate-spin" />
                               )}
-                              {deactivatedValveIds.has(seId) ? "Activate" : "Deactivate"}
+                              <Power className="h-3 w-3" />
                             </Button>
                           </TableCell>
                         </TableRow>

--- a/src/components/ValvePointsEditor.tsx
+++ b/src/components/ValvePointsEditor.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { LeafletMap } from "@/components/LeafletMap";
 import { RGISMap } from "@/components/RGISMap";
 import { Label } from "@/components/ui/label";
@@ -15,9 +16,10 @@ import {
 import { SortableTableHead } from "@/components/ui/sortable-table-head";
 import { Pagination } from "@/components/ui/pagination";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { MapPin, AlertTriangle } from "lucide-react";
+import { MapPin, AlertTriangle, Loader2 } from "lucide-react";
 import { useTable } from "@/hooks/use-table";
 import { useDeviceLogs } from "@/hooks/useApiQueries";
+import { useToast } from "@/hooks/use-toast";
 import { API_BASE_PATH } from "@/lib/api";
 
 // Dynamic row type for arbitrary property names
@@ -46,11 +48,14 @@ interface MapPipelineSegment {
 }
 
 export const ValvePointsEditor = () => {
+  const { toast } = useToast();
   const [showRGIS, setShowRGIS] = useState(true);
   const [rows, setRows] = useState<DynamicRow[]>([]);
   const [columns, setColumns] = useState<string[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const [deactivatedValveIds, setDeactivatedValveIds] = useState<Set<string>>(new Set());
+  const [loadingValveIds, setLoadingValveIds] = useState<Set<string>>(new Set());
 
   const [pipelineRows, setPipelineRows] = useState<DynamicRow[]>([]);
   const [pipelineError, setPipelineError] = useState<string | null>(null);
@@ -201,6 +206,44 @@ export const ValvePointsEditor = () => {
   const showPipelines = mapPipelines.length > 0;
   const showValves = mapValves.length > 0;
 
+  const handleToggleValveDeactivate = async (seId: string) => {
+    setLoadingValveIds((prev) => new Set(prev).add(seId));
+    try {
+      const url = `${API_BASE_PATH}/SurveyEntries/deactivate-survey-entry?seId=${encodeURIComponent(seId)}`;
+      const response = await fetch(url, { method: "POST" });
+      if (!response.ok) {
+        throw new Error(`Failed to deactivate entry: ${response.status}`);
+      }
+      setDeactivatedValveIds((prev) => {
+        const newSet = new Set(prev);
+        if (newSet.has(seId)) {
+          newSet.delete(seId);
+        } else {
+          newSet.add(seId);
+        }
+        return newSet;
+      });
+      const isDeactivating = !deactivatedValveIds.has(seId);
+      toast({
+        title: isDeactivating ? "Deactivated" : "Activated",
+        description: `Valve entry ${isDeactivating ? "deactivated" : "activated"} successfully`,
+      });
+    } catch (error) {
+      console.error("Error toggling deactivation:", error);
+      toast({
+        title: "Error",
+        description: "Failed to update entry status",
+        variant: "destructive",
+      });
+    } finally {
+      setLoadingValveIds((prev) => {
+        const newSet = new Set(prev);
+        newSet.delete(seId);
+        return newSet;
+      });
+    }
+  };
+
   return (
     <div className="p-6 space-y-6">
       <div className="flex items-center justify-between">
@@ -274,33 +317,55 @@ export const ValvePointsEditor = () => {
                       {columns.length === 0 ? (
                         <TableHead>No data</TableHead>
                       ) : (
-                        columns.map((col) => (
-                          <SortableTableHead
-                            key={col}
-                            sortKey={col}
-                            currentSortKey={tableConfig.sortConfig.key as unknown as string}
-                            sortDirection={tableConfig.sortConfig.direction}
-                            onSort={(k) => tableConfig.handleSort(k as keyof DynamicRow)}
-                          >
-                            {col}
+                        <>
+                          {columns.map((col) => (
+                            <SortableTableHead
+                              key={col}
+                              sortKey={col}
+                              currentSortKey={tableConfig.sortConfig.key as unknown as string}
+                              sortDirection={tableConfig.sortConfig.direction}
+                              onSort={(k) => tableConfig.handleSort(k as keyof DynamicRow)}
+                            >
+                              {col}
+                            </SortableTableHead>
+                          ))}
+                          <SortableTableHead sortable={false} className="text-right">
+                            Action
                           </SortableTableHead>
-                        ))
+                        </>
                       )}
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {sortedAndPaginatedData.map((row, idx) => (
-                      <TableRow key={String(row.id ?? idx)}>
-                        {columns.map((col) => {
-                          const value = row[col];
-                          return (
-                            <TableCell key={col}>
-                              {value === null || value === undefined || value === "" ? "-" : String(value)}
-                            </TableCell>
-                          );
-                        })}
-                      </TableRow>
-                    ))}
+                    {sortedAndPaginatedData.map((row, idx) => {
+                      const seId = String(row.SE_ID ?? row.id ?? idx);
+                      return (
+                        <TableRow key={seId}>
+                          {columns.map((col) => {
+                            const value = row[col];
+                            return (
+                              <TableCell key={col}>
+                                {value === null || value === undefined || value === "" ? "-" : String(value)}
+                              </TableCell>
+                            );
+                          })}
+                          <TableCell className="text-right">
+                            <Button
+                              variant={deactivatedValveIds.has(seId) ? "outline" : "default"}
+                              size="sm"
+                              onClick={() => handleToggleValveDeactivate(seId)}
+                              disabled={loadingValveIds.has(seId)}
+                              className="gap-1"
+                            >
+                              {loadingValveIds.has(seId) && (
+                                <Loader2 className="h-3 w-3 animate-spin" />
+                              )}
+                              {deactivatedValveIds.has(seId) ? "Activate" : "Deactivate"}
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
                   </TableBody>
                 </Table>
               )}


### PR DESCRIPTION
### Summary
Adds a **Status** badge column and an **Action** button column to the data grids in `CatastropheList`, `PipelineNetworkEditor`, and `ValvePointsEditor`, allowing users to toggle the active/inactive state of individual survey entries via the deactivate API.

### Problem
The grids in the three editor pages had no way to activate or deactivate individual survey entries. Users needed an in-grid control to manage entry status without navigating away.

### Solution
Added a `Status` column displaying an `Active`/`Inactive` badge and an `Action` column with a toggle button (Power icon) in each grid. Clicking the button calls the `deactivate-survey-entry` API endpoint and updates the displayed status accordingly, with toast notifications for success and error feedback.

### Key Changes
- **`CatastropheList.tsx`**: Added `Status` (badge) and `Action` (Power button) columns; introduced `deactivatedItems` and `loadingIds` state; implemented `handleToggleDeactivate` calling `${API_BASE_PATH}/SurveyEntries/deactivate-survey-entry?seId=`.
- **`PipelineNetworkEditor.tsx`**: Added `Status` and `Action` columns to the pipeline properties grid; introduced `deactivatedPipelineIds` and `loadingPipelineIds` state; implemented `handleTogglePipelineDeactivate` with the same API endpoint.
- **`ValvePointsEditor.tsx`**: Added `Status` and `Action` columns to the valve points grid; introduced `deactivatedValveIds` and `loadingValveIds` state; implemented `handleToggleValveDeactivate` with the same API endpoint.
- All API calls use the dynamic `${API_BASE_PATH}` constant — no hardcoded paths.
- Loading state per row is tracked individually, showing a spinner (`Loader2`) on the action button while the request is in flight.
- Status is displayed as a `Badge` (`Active` / `Inactive`) rather than button styling changes.

---

<a href="https://builder.io/app/projects/fafa5a82811f47968513a2866280018e/molten-tooth-alei9wxn"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://fafa5a82811f47968513a2866280018e-molten-tooth-alei9wxn_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 231`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fafa5a82811f47968513a2866280018e</projectId>-->
<!--<branchName>molten-tooth-alei9wxn</branchName>-->